### PR TITLE
fix: entire top nav bar is hot spot for Go Home, should only be app title

### DIFF
--- a/src/frontend/src/components/Header/Header.tsx
+++ b/src/frontend/src/components/Header/Header.tsx
@@ -9,14 +9,16 @@ import { Subtitle2 } from "@fluentui/react-components";
  * @prop {string} [title="Microsoft"] - Main title text.
  * @prop {string} [subtitle] - Optional subtitle displayed next to the title.
  * @prop {React.ReactNode} [children] - Optional header toolbar (e.g., buttons, menus).
+ * @prop {() => void} [onTitleClick] - Optional click handler for title/logo area.
  */
 type HeaderProps = {
   title?: string;
   subtitle?: string;
   children?: React.ReactNode;
+  onTitleClick?: () => void;
 };
 
-const Header: React.FC<HeaderProps> = ({ title = "Contoso", subtitle, children }) => {
+const Header: React.FC<HeaderProps> = ({ title = "Contoso", subtitle, children, onTitleClick }) => {
   return (
     <header
       style={{
@@ -36,11 +38,13 @@ const Header: React.FC<HeaderProps> = ({ title = "Contoso", subtitle, children }
       data-figma-component="Header"
     >
       <div
+        onClick={onTitleClick}
         style={{
           display: "flex",
           justifyContent: "space-between",
           alignItems: "center",
           gap: "8px",
+          cursor: onTitleClick ? "pointer" : "default",
         }}
       >
         {/* Render custom logo or default MsftColor logo */}

--- a/src/frontend/src/pages/batchView.tsx
+++ b/src/frontend/src/pages/batchView.tsx
@@ -574,14 +574,10 @@ const BatchStoryPage = () => {
   if (!dataLoaded && loading) {
     return (
       <div className={styles.root}>
-        <div onClick={handleHeaderClick} style={{ cursor: "pointer" }}>
-          <Header subtitle="Container Migration">
-            <div onClick={(e) => e.stopPropagation()}>
-              <HeaderTools>
-              </HeaderTools>
-            </div>
-          </Header>
-        </div>
+        <Header subtitle="Container Migration" onTitleClick={handleHeaderClick}>
+          <HeaderTools>
+          </HeaderTools>
+        </Header>
         <div className={styles.loadingContainer} style={{ flex: 1 }}>
           <Spinner size="large" />
           <Text size={500}>Loading batch data...</Text>
@@ -592,14 +588,10 @@ const BatchStoryPage = () => {
 
   return (
     <div className={styles.root}>
-      <div onClick={handleHeaderClick} style={{ cursor: "pointer" }}>
-        <Header subtitle="Container Migration">
-          <div onClick={(e) => e.stopPropagation()}>
-            <HeaderTools>
-            </HeaderTools>
-          </div>
-        </Header>
-      </div>
+      <Header subtitle="Container Migration" onTitleClick={handleHeaderClick}>
+        <HeaderTools>
+        </HeaderTools>
+      </Header>
 
       <div className={styles.content}>
         <PanelLeft panelWidth={400} panelResize={true}>

--- a/src/frontend/src/pages/landingPage.tsx
+++ b/src/frontend/src/pages/landingPage.tsx
@@ -92,14 +92,10 @@ export const LandingPage = (): JSX.Element => {
   return (
     <div className="landing-page flex flex-col relative h-screen">
       {/* Header */}
-      <div onClick={handleLeave} style={{ cursor: "pointer" }}>
-        <Header subtitle="Container Migration">
-          <div onClick={(e) => e.stopPropagation()}>
-            <HeaderTools>
-            </HeaderTools>
-          </div>
-        </Header>
-      </div>
+      <Header subtitle="Container Migration" onTitleClick={handleLeave}>
+        <HeaderTools>
+        </HeaderTools>
+      </Header>
       {/* Main Content */}
       <main className={`main-content ${isPanelOpen ? "shifted" : ""} flex-1 flex overflow-auto bg-mode-neutral-background-1-rest relative`}>
         <div className="container mx-auto flex flex-col items-center justify-center px-4 sm:px-6 lg:px-8">

--- a/src/frontend/src/pages/processPage.tsx
+++ b/src/frontend/src/pages/processPage.tsx
@@ -364,12 +364,10 @@ const ProcessPage: React.FC = () => {
       <style dangerouslySetInnerHTML={{ __html: scrollbarStyles }} />
       <div className="landing-page flex flex-col relative h-screen">
         {/* Header - Same as Landing Page */}
-        <div onClick={handleLeave} style={{ cursor: "pointer" }}>
-          <Header subtitle="Container Migration">
-            <HeaderTools>
-            </HeaderTools>
-          </Header>
-        </div>
+        <Header subtitle="Container Migration" onTitleClick={handleLeave}>
+          <HeaderTools>
+          </HeaderTools>
+        </Header>
 
         {/* Main Content */}
         <main className={`main-content ${isPanelOpen ? "shifted" : ""} flex-1 flex overflow-auto bg-mode-neutral-background-1-rest relative`}>


### PR DESCRIPTION
This pull request refactors the way click handling is implemented for the header component across several pages. Instead of wrapping the `Header` in a clickable `div`, the header now directly accepts an `onTitleClick` prop, simplifying the structure and making the click behavior more explicit and maintainable.

**Header component enhancements:**

* Added an `onTitleClick` prop to the `Header` component, allowing a click handler to be passed directly for the title/logo area. The cursor style is now conditionally set to "pointer" when a handler is provided. [[1]](diffhunk://#diff-60c8977e1cdd5ee5d6c06ac4d46e3ff61dc209107286a059410fbd651e58835bR12-R21) [[2]](diffhunk://#diff-60c8977e1cdd5ee5d6c06ac4d46e3ff61dc209107286a059410fbd651e58835bR41-R47)

**Page-level refactoring for click handling:**

* Updated `batchView.tsx`, `landingPage.tsx`, and `processPage.tsx` to use the new `onTitleClick` prop on the `Header` component, removing the extra wrapping `div` and associated event handling logic. This results in cleaner and more consistent code across these pages. [[1]](diffhunk://#diff-cdeb9de1e80ac6996465fb16cd07e14aa8d7467e05252cbcae76fe15b40efb7bL577-L584) [[2]](diffhunk://#diff-cdeb9de1e80ac6996465fb16cd07e14aa8d7467e05252cbcae76fe15b40efb7bL595-L602) [[3]](diffhunk://#diff-767741198a3d2e04561918b0f51942a0476d7753fb42f719fd71c675d2ddcd05L95-L102) [[4]](diffhunk://#diff-f32d12a633e687fecb91ca595f1831e87f4ce9237394e733dd968a2a0d5c5ff2L367-L372)