### PR TITLE
Add docker-in-docker feature to devcontainer configuration

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -5,7 +5,8 @@
         "ghcr.io/dhoeric/features/hadolint:1": {},
         "ghcr.io/jsburckhardt/devcontainer-features/uv:1": {},
         "ghcr.io/devcontainers/features/azure-cli:1": {},
-        "ghcr.io/azure/azure-dev/azd:latest": {}
+        "ghcr.io/azure/azure-dev/azd:latest": {},
+        "ghcr.io/devcontainers/features/docker-in-docker:2": {}
     },
     "customizations": {
         "vscode": {


### PR DESCRIPTION
This pull request makes a minor update to the development container configuration by adding support for Docker-in-Docker. This enables running Docker commands inside the dev container, which can be useful for testing containerized workflows.

* Dev environment enhancement:
  * [`.devcontainer/devcontainer.json`](diffhunk://#diff-24ad71c8613ddcf6fd23818cb3bb477a1fb6d83af4550b0bad43099813088686L8-R9): Added the `ghcr.io/devcontainers/features/docker-in-docker:2` feature to allow Docker commands to be executed inside the container.