### PR TITLE
fix: patch path traversal (CWE-22) and harden /config endpoint [MSRC 112301]

### DIFF
--- a/infra/main.bicep
+++ b/infra/main.bicep
@@ -1231,6 +1231,10 @@ module containerAppFrontend 'br/public:avm/res/app/container-app:0.18.1' = {
             name: 'REACT_APP_MSAL_REDIRECT_URL'
             value: '/'
           }
+          {
+            name: 'ALLOWED_ORIGINS'
+            value: 'https://${frontEndContainerAppName}.${containerAppsEnvironment.outputs.defaultDomain}'
+          }
         ]
         resources: {
           cpu: '1'

--- a/infra/main.json
+++ b/infra/main.json
@@ -6,7 +6,7 @@
     "_generator": {
       "name": "bicep",
       "version": "0.41.2.15936",
-      "templateHash": "8495628770560205121"
+      "templateHash": "10582002328170601028"
     }
   },
   "parameters": {
@@ -26120,8 +26120,8 @@
       },
       "dependsOn": [
         "appIdentity",
-        "[format('avmPrivateDnsZones[{0}]', variables('dnsZoneIndex').storageQueue)]",
         "[format('avmPrivateDnsZones[{0}]', variables('dnsZoneIndex').storageBlob)]",
+        "[format('avmPrivateDnsZones[{0}]', variables('dnsZoneIndex').storageQueue)]",
         "virtualNetwork"
       ]
     },
@@ -33808,9 +33808,9 @@
       },
       "dependsOn": [
         "aiFoundryAiServices",
+        "[format('avmPrivateDnsZones[{0}]', variables('dnsZoneIndex').cognitiveServices)]",
         "[format('avmPrivateDnsZones[{0}]', variables('dnsZoneIndex').aiServices)]",
         "[format('avmPrivateDnsZones[{0}]', variables('dnsZoneIndex').openAI)]",
-        "[format('avmPrivateDnsZones[{0}]', variables('dnsZoneIndex').cognitiveServices)]",
         "virtualNetwork"
       ]
     },
@@ -40908,6 +40908,10 @@
                   {
                     "name": "REACT_APP_MSAL_REDIRECT_URL",
                     "value": "/"
+                  },
+                  {
+                    "name": "ALLOWED_ORIGINS",
+                    "value": "[format('https://{0}.{1}', variables('frontEndContainerAppName'), reference('containerAppsEnvironment').outputs.defaultDomain.value)]"
                   }
                 ],
                 "resources": {

--- a/infra/main_custom.bicep
+++ b/infra/main_custom.bicep
@@ -1229,6 +1229,10 @@ module containerAppFrontend 'br/public:avm/res/app/container-app:0.18.1' = {
             name: 'APP_ENV'
             value: 'prod'
           }
+          {
+            name: 'ALLOWED_ORIGINS'
+            value: 'https://${frontEndContainerAppName}.${containerAppsEnvironment.outputs.defaultDomain}'
+          }
         ]
         resources: {
           cpu: '1'

--- a/src/frontend/frontend_server.py
+++ b/src/frontend/frontend_server.py
@@ -2,9 +2,9 @@ import os
 
 import uvicorn
 from dotenv import load_dotenv
-from fastapi import FastAPI
+from fastapi import FastAPI, Request
 from fastapi.middleware.cors import CORSMiddleware
-from fastapi.responses import FileResponse, HTMLResponse
+from fastapi.responses import FileResponse, HTMLResponse, JSONResponse
 from fastapi.staticfiles import StaticFiles
 
 # Load environment variables from .env file
@@ -12,10 +12,14 @@ load_dotenv()
 
 app = FastAPI()
 
+# Read allowed origins from environment; fall back to same-origin only
+_allowed_origins = os.getenv("ALLOWED_ORIGINS", "").split(",")
+_allowed_origins = [o.strip() for o in _allowed_origins if o.strip()]
+
 app.add_middleware(
     CORSMiddleware,
-    allow_origins=["*"],
-    allow_methods=["*"],
+    allow_origins=_allowed_origins,
+    allow_methods=["GET"],
     allow_headers=["*"],
 )
 
@@ -35,20 +39,27 @@ async def serve_index():
 
 
 @app.get("/config")
-async def get_config():
+async def get_config(request: Request):
+    # Only serve config to same-origin requests by checking the Referer/Origin
+    origin = request.headers.get("origin") or ""
+    referer = request.headers.get("referer") or ""
+    host = request.headers.get("host") or ""
+    if origin and not origin.endswith(host):
+        return JSONResponse(status_code=403, content={"detail": "Forbidden"})
+
     config = {
-        "API_URL": os.getenv("API_URL", "API_URL not set"),
+        "API_URL": os.getenv("API_URL", ""),
         "REACT_APP_MSAL_AUTH_CLIENTID": os.getenv(
-            "REACT_APP_MSAL_AUTH_CLIENTID", "Client ID not set"
+            "REACT_APP_MSAL_AUTH_CLIENTID", ""
         ),
         "REACT_APP_MSAL_AUTH_AUTHORITY": os.getenv(
-            "REACT_APP_MSAL_AUTH_AUTHORITY", "Authority not set"
+            "REACT_APP_MSAL_AUTH_AUTHORITY", ""
         ),
         "REACT_APP_MSAL_REDIRECT_URL": os.getenv(
-            "REACT_APP_MSAL_REDIRECT_URL", "Redirect URL not set"
+            "REACT_APP_MSAL_REDIRECT_URL", ""
         ),
         "REACT_APP_MSAL_POST_REDIRECT_URL": os.getenv(
-            "REACT_APP_MSAL_POST_REDIRECT_URL", "Post Redirect URL not set"
+            "REACT_APP_MSAL_POST_REDIRECT_URL", ""
         ),
         "REACT_APP_WEB_SCOPE": os.getenv(
             "REACT_APP_WEB_SCOPE", ""
@@ -63,9 +74,12 @@ async def get_config():
 
 @app.get("/{full_path:path}")
 async def serve_app(full_path: str):
-    # First check if file exists in build directory
-    file_path = os.path.join(BUILD_DIR, full_path)
-    if os.path.exists(file_path):
+    # Resolve the requested path and ensure it stays within BUILD_DIR
+    file_path = os.path.realpath(os.path.join(BUILD_DIR, full_path))
+    build_dir_real = os.path.realpath(BUILD_DIR)
+    if not file_path.startswith(build_dir_real + os.sep) and file_path != build_dir_real:
+        return FileResponse(INDEX_HTML)
+    if os.path.isfile(file_path):
         return FileResponse(file_path)
     # Otherwise serve index.html for client-side routing
     return FileResponse(INDEX_HTML)


### PR DESCRIPTION
## Purpose
Fixes a **Path Traversal (CWE-22)** security vulnerability in `src/frontend/frontend_server.py` reported via **MSRC Case 112301** (Deadline: 8/2/2026).

The catch-all route passed user-supplied URL paths directly to `os.path.join()` without sanitization, allowing unauthenticated attackers to read arbitrary files on the container filesystem (`/etc/passwd`, application source, Azure credentials in `/proc/self/environ`) via URL-encoded `..%2F` traversal sequences. Additionally, the `/config` endpoint exposed MSAL client IDs, Azure AD authority, and API scopes to any unauthenticated cross-origin caller due to `allow_origins=["*"]` CORS policy.

### Changes
- **Path traversal fix:** Use `os.path.realpath()` to canonicalize the resolved path and verify it stays within `BUILD_DIR`
- **Directory listing prevention:** Replace `os.path.exists()` with `os.path.isfile()` to only serve regular files
- **CORS hardening:** Replace wildcard `*` origin with configurable `ALLOWED_ORIGINS` environment variable (defaults to empty = same-origin only); restrict methods to GET
- **/config endpoint protection:** Add origin-vs-host validation to block cross-origin credential reads; remove verbose fallback strings

### Related
- **MSRC Case:** 112301
- **ADO Bug:** [39317](https://dev.azure.com/CSACTOSOL/03e03490-e6d3-4222-9888-dfe81f0e986a/_workitems/edit/39317)
- **Deadline:** 8/2/2026

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

> The `ALLOWED_ORIGINS` env var defaults to empty (same-origin), which matches the expected production behavior. Set `ALLOWED_ORIGINS` if explicit cross-origin access is needed.

## Golden Path Validation
- [x] I have tested the primary workflows (the "golden path") to ensure they function correctly without errors.

## Deployment Validation
- [ ] I have validated the deployment process successfully and all services are running as expected with this change.

## What to Check
Verify that the following are valid
* Path traversal payloads (e.g. `curl "http://localhost:3000/..%2F..%2Fetc%2Fpasswd"`) now return `index.html` instead of the target file
* `/config` endpoint returns 403 for cross-origin requests
* Frontend SPA routing still works correctly (all client-side routes serve `index.html`)
* Static assets under `/assets/` still load normally

## Other Information
This is a security fix for a vulnerability reported by an external researcher. **Do not share vulnerability details outside the MSRC case.** Resolution deadline is **8/2/2026**.
