### PR TITLE
fix: removed the bicep parameter

### DIFF
--- a/azure.yaml
+++ b/azure.yaml
@@ -6,7 +6,6 @@ metadata:
 
 requiredVersions:
   azd: '>=1.18.2 != 1.23.9'
-  bicep: '>= 0.33.0'
 
 hooks:
   postdeploy:


### PR DESCRIPTION
## Purpose
Removed `bicep: '>= 0.33.0'` from the `requiredVersions` section in `azure.yaml`.

Related work items: AB#40862

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

## Golden Path Validation
- [x] I have tested the primary workflows (the "golden path") to ensure they function correctly without errors.

## Deployment Validation
- [x] I have validated the deployment process successfully and all services are running as expected with this change.

## What to Check
Verify that the following are valid
* `azure.yaml` deploys successfully without the bicep version constraint

## Other Information
- Related to ADO User Story #40862
