### PR TITLE
fix(ci): disable buildx provenance to fix ACR Standard push (400)

### DIFF
--- a/.github/workflows/docker-build-and-push.yml
+++ b/.github/workflows/docker-build-and-push.yml
@@ -92,6 +92,7 @@ jobs:
           context: ./src/backend-api
           file: ./src/backend-api/Dockerfile
           push: ${{ github.event_name != 'pull_request' && (github.ref_name == 'main' || github.ref_name == 'dev' || github.ref_name == 'demo' || github.ref_name == 'hotfix') }}
+          provenance: false
           tags: |
             ${{ steps.registry.outputs.ext_registry }}/backend-api:${{ env.BASE_TAG }}
             ${{ steps.registry.outputs.ext_registry }}/backend-api:${{ env.DATE_TAG }}
@@ -102,6 +103,7 @@ jobs:
           context: ./src/processor
           file: ./src/processor/Dockerfile
           push: ${{ github.event_name != 'pull_request' && (github.ref_name == 'main' || github.ref_name == 'dev' || github.ref_name == 'demo' || github.ref_name == 'hotfix') }}
+          provenance: false
           tags: |
             ${{ steps.registry.outputs.ext_registry }}/processor:${{ env.BASE_TAG }}
             ${{ steps.registry.outputs.ext_registry }}/processor:${{ env.DATE_TAG }}
@@ -112,6 +114,7 @@ jobs:
           context: ./src/frontend
           file: ./src/frontend/Dockerfile
           push: ${{ github.event_name != 'pull_request' && (github.ref_name == 'main' || github.ref_name == 'dev' || github.ref_name == 'demo' || github.ref_name == 'hotfix') }}
+          provenance: false
           tags: |
             ${{ steps.registry.outputs.ext_registry }}/frontend:${{ env.BASE_TAG }}
             ${{ steps.registry.outputs.ext_registry }}/frontend:${{ env.DATE_TAG }}

--- a/.github/workflows/job-docker-build.yml
+++ b/.github/workflows/job-docker-build.yml
@@ -67,6 +67,7 @@ jobs:
           context: ./src/backend-api
           file: ./src/backend-api/Dockerfile
           push: true
+          provenance: false
           tags: |
             ${{ secrets.ACR_TEST_LOGIN_SERVER }}/backend-api:${{ steps.generate_docker_tag.outputs.IMAGE_TAG }}
             ${{ secrets.ACR_TEST_LOGIN_SERVER }}/backend-api:${{ steps.generate_docker_tag.outputs.IMAGE_TAG }}_${{ github.run_number }}
@@ -79,6 +80,7 @@ jobs:
           context: ./src/processor
           file: ./src/processor/Dockerfile
           push: true
+          provenance: false
           tags: |
             ${{ secrets.ACR_TEST_LOGIN_SERVER }}/processor:${{ steps.generate_docker_tag.outputs.IMAGE_TAG }}
             ${{ secrets.ACR_TEST_LOGIN_SERVER }}/processor:${{ steps.generate_docker_tag.outputs.IMAGE_TAG }}_${{ github.run_number }}
@@ -91,6 +93,7 @@ jobs:
           context: ./src/frontend
           file: ./src/frontend/Dockerfile
           push: true
+          provenance: false
           tags: |
             ${{ secrets.ACR_TEST_LOGIN_SERVER }}/frontend:${{ steps.generate_docker_tag.outputs.IMAGE_TAG }}
             ${{ secrets.ACR_TEST_LOGIN_SERVER }}/frontend:${{ steps.generate_docker_tag.outputs.IMAGE_TAG }}_${{ github.run_number }}


### PR DESCRIPTION
ACR Standard SKU does not support OCI image indexes containing buildx attestation manifests, causing docker/build-push-action to fail with '400 Bad Request' on the manifest HEAD/PUT step.

Set provenance: false on all docker/build-push-action@v6 steps in:
  - .github/workflows/docker-build-and-push.yml
  - .github/workflows/job-docker-build.yml

## Purpose
<!-- Describe the intention of the changes being proposed. What problem does it solve or functionality does it add? -->
* ...

## Does this introduce a breaking change?
<!-- Mark one with an "x". -->

- [ ] Yes
- [ ] No

<!-- Please prefix your PR title with one of the following:
  * `feat`: A new feature
  * `fix`: A bug fix
  * `docs`: Documentation only changes
  * `style`: Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc)
  * `refactor`: A code change that neither fixes a bug nor adds a feature
  * `perf`: A code change that improves performance
  * `test`: Adding missing tests or correcting existing tests
  * `build`: Changes that affect the build system or external dependencies (example scopes: gulp, broccoli, npm)
  * `ci`: Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
  * `chore`: Other changes that don't modify src or test files
  * `revert`: Reverts a previous commit
  * !: A breaking change is indicated with a `!` after the listed prefixes above, e.g. `feat!`, `fix!`, `refactor!`, etc.
-->

## Golden Path Validation
- [ ] I have tested the primary workflows (the "golden path") to ensure they function correctly without errors.

## Deployment Validation
- [ ] I have validated the deployment process successfully and all services are running as expected with this change.

## What to Check
Verify that the following are valid
* ...

## Other Information

<!-- Add any other helpful information that may be needed here. -->
