### PR TITLE
fix: API Endpoint Backend C_Migration

### DIFF
--- a/docs/DeploymentGuide.md
+++ b/docs/DeploymentGuide.md
@@ -191,6 +191,8 @@ Review the configuration options below. You can customize any settings that meet
 | **Framework**          | Basic configuration               | [Well-Architected Framework](https://learn.microsoft.com/en-us/azure/well-architected/) |
 | **Features**           | Core functionality                | Reliability, security, operational excellence                                           |
 
+When you use the production WAF configuration for Container Migration, only the frontend Container App stays publicly reachable through Application Gateway/WAF. The backend API and processor Container Apps stay on internal ingress inside the Container Apps environment, and the existing VNet subnet/NSG rules continue to limit traffic to internal paths.
+
 **To use production configuration:**
 
 Copy the contents from the production configuration file to your main parameters file:

--- a/infra/main.bicep
+++ b/infra/main.bicep
@@ -1220,7 +1220,7 @@ module containerAppBackend 'br/public:avm/res/app/container-app:0.18.1' = {
       }
     ]
     ingressTargetPort: backendContainerPort
-    ingressExternal: true
+    ingressExternal: enablePrivateNetworking ? false : true // WAF: internal-only ingress for backend API
     scaleSettings: {
       maxReplicas: enableScalability ? 3 : 1
       minReplicas: 1
@@ -1278,7 +1278,14 @@ module containerAppFrontend 'br/public:avm/res/app/container-app:0.18.1' = {
         env: [
           {
             name: 'API_URL'
-            value: 'https://${containerAppBackend.outputs.fqdn}'
+            // Frontend calls same-origin /api; frontend server proxies to backend.
+            value: '/api'
+          }
+          {
+            name: 'BACKEND_API_URL'
+            value: enablePrivateNetworking
+              ? 'https://${backendContainerAppName}.internal.${containerAppsEnvironment.outputs.defaultDomain}'
+              : 'https://${containerAppBackend.outputs.fqdn}'
           }
           {
             name: 'APP_ENV'

--- a/infra/main_custom.bicep
+++ b/infra/main_custom.bicep
@@ -1165,7 +1165,7 @@ module containerAppBackend 'br/public:avm/res/app/container-app:0.18.1' = {
       }
     ]
     ingressTargetPort: backendContainerPort
-    ingressExternal: true
+    ingressExternal: enablePrivateNetworking ? false : true
     scaleSettings: {
       maxReplicas: enableScalability ? 3 : 1
       minReplicas: 1
@@ -1229,7 +1229,13 @@ module containerAppFrontend 'br/public:avm/res/app/container-app:0.18.1' = {
         env: [
           {
             name: 'API_URL'
-            value: 'https://${containerAppBackend.outputs.fqdn}'
+            value: '/api'
+          }
+          {
+            name: 'BACKEND_API_URL'
+            value: enablePrivateNetworking
+              ? 'https://${backendContainerAppName}.internal.${containerAppsEnvironment.outputs.defaultDomain}'
+              : 'https://${containerAppBackend.outputs.fqdn}'
           }
           {
             name: 'APP_ENV'
@@ -1382,7 +1388,9 @@ output AZURE_CONTAINER_REGISTRY_ENDPOINT string = containerRegistry.outputs.logi
 output SERVICE_BACKEND_NAME string = containerAppBackend.outputs.name
 
 @description('Backend service container app URI')
-output SERVICE_BACKEND_URI string = 'https://${containerAppBackend.outputs.fqdn}'
+output SERVICE_BACKEND_URI string = enablePrivateNetworking
+  ? 'https://${backendContainerAppName}.internal.${containerAppsEnvironment.outputs.defaultDomain}'
+  : 'https://${containerAppBackend.outputs.fqdn}'
 
 @description('Processor service container app name')  
 output SERVICE_PROCESSOR_NAME string = containerAppProcessor.outputs.name

--- a/src/frontend/frontend_server.py
+++ b/src/frontend/frontend_server.py
@@ -90,26 +90,43 @@ async def proxy_api(full_path: str, request: Request):
 
     body = await request.body()
 
-    async with httpx.AsyncClient(timeout=120.0, follow_redirects=True) as client:
-        proxied = await client.request(
-            method=request.method,
-            url=target_url,
-            headers=headers,
-            content=body,
+    try:
+        async with httpx.AsyncClient(timeout=120.0, follow_redirects=True) as client:
+            proxied = await client.request(
+                method=request.method,
+                url=target_url,
+                headers=headers,
+                content=body,
+            )
+    except httpx.TimeoutException:
+        return JSONResponse(
+            status_code=504,
+            content={"detail": "Upstream backend request timed out"},
+        )
+    except httpx.RequestError:
+        return JSONResponse(
+            status_code=502,
+            content={"detail": "Failed to reach upstream backend"},
         )
 
-    passthrough_headers = {
-        key: value
-        for key, value in proxied.headers.items()
-        if key.lower() not in {"content-encoding", "transfer-encoding", "connection"}
+    excluded_headers = {
+        "content-encoding",
+        "transfer-encoding",
+        "connection",
+        "content-length",
+        "content-type",
     }
 
-    return Response(
+    response = Response(
         content=proxied.content,
         status_code=proxied.status_code,
-        headers=passthrough_headers,
         media_type=proxied.headers.get("content-type"),
     )
+    for key, value in proxied.headers.multi_items():
+        if key.lower() not in excluded_headers:
+            response.raw_headers.append((key.encode("latin-1"), value.encode("latin-1")))
+
+    return response
 
 
 @app.get("/{full_path:path}")

--- a/src/frontend/frontend_server.py
+++ b/src/frontend/frontend_server.py
@@ -1,16 +1,19 @@
 import os
 
+import httpx
 import uvicorn
 from dotenv import load_dotenv
 from fastapi import FastAPI, Request
 from fastapi.middleware.cors import CORSMiddleware
-from fastapi.responses import FileResponse, HTMLResponse, JSONResponse
+from fastapi.responses import FileResponse, JSONResponse, Response
 from fastapi.staticfiles import StaticFiles
 
 # Load environment variables from .env file
 load_dotenv()
 
 app = FastAPI()
+
+BACKEND_API_URL = os.getenv("BACKEND_API_URL", "").rstrip("/")
 
 # Read allowed origins from environment; fall back to same-origin only
 _allowed_origins = os.getenv("ALLOWED_ORIGINS", "").split(",")
@@ -70,6 +73,43 @@ async def get_config(request: Request):
         "ENABLE_AUTH": os.getenv("ENABLE_AUTH", "false"),
     }
     return config
+
+
+@app.api_route("/api/{full_path:path}", methods=["GET", "POST", "PUT", "PATCH", "DELETE", "OPTIONS"])
+async def proxy_api(full_path: str, request: Request):
+    if not BACKEND_API_URL:
+        return JSONResponse(status_code=503, content={"detail": "Backend API URL is not configured"})
+
+    target_url = f"{BACKEND_API_URL}/api/{full_path}"
+    if request.url.query:
+        target_url = f"{target_url}?{request.url.query}"
+
+    headers = dict(request.headers)
+    headers.pop("host", None)
+    headers.pop("content-length", None)
+
+    body = await request.body()
+
+    async with httpx.AsyncClient(timeout=120.0, follow_redirects=True) as client:
+        proxied = await client.request(
+            method=request.method,
+            url=target_url,
+            headers=headers,
+            content=body,
+        )
+
+    passthrough_headers = {
+        key: value
+        for key, value in proxied.headers.items()
+        if key.lower() not in {"content-encoding", "transfer-encoding", "connection"}
+    }
+
+    return Response(
+        content=proxied.content,
+        status_code=proxied.status_code,
+        headers=passthrough_headers,
+        media_type=proxied.headers.get("content-type"),
+    )
 
 
 @app.get("/{full_path:path}")

--- a/src/frontend/requirements.txt
+++ b/src/frontend/requirements.txt
@@ -1,6 +1,7 @@
 fastapi==0.116.1
 uvicorn[standard]==0.35.0
 # uvicorn removed and added above to allow websocket support
+httpx==0.28.1
 jinja2==3.1.6
 azure-identity==1.24.0
 python-dotenv==1.1.1


### PR DESCRIPTION
This pull request introduces a production-ready networking configuration for containerized applications, focusing on improved security by restricting backend API access to internal networks and implementing a frontend proxy pattern. The main changes include updating the infrastructure-as-code to support private networking, adjusting environment variables, and introducing an API proxy in the frontend server to route requests securely.

**Infrastructure and Networking Changes:**

* The backend API container app's ingress is now internal-only when private networking is enabled, ensuring it is not publicly accessible. Only the frontend container app remains publicly reachable through the Application Gateway/WAF. [[1]](diffhunk://#diff-7ef659fc9cf6968e718894d300490b14ea7a52091e7d4bcffae3a5029ac721d4L1223-R1223) [[2]](diffhunk://#diff-6f5772bf1f1d80cc16f30c80915d9e5622ad0637daf5b5dff29308ad5fc68b62L1168-R1168)
* The output for the backend service URI now conditionally uses the internal domain if private networking is enabled, otherwise it uses the public FQDN.
* Documentation was updated to clarify that only the frontend is publicly accessible in production WAF configuration, with backend and processor apps remaining internal.

**Frontend Environment and API Proxy:**

* The frontend's environment variables are updated: `API_URL` is set to `/api` for same-origin calls, and a new `BACKEND_API_URL` variable is introduced to handle both internal and public backend URIs based on the networking configuration. [[1]](diffhunk://#diff-7ef659fc9cf6968e718894d300490b14ea7a52091e7d4bcffae3a5029ac721d4L1281-R1288) [[2]](diffhunk://#diff-6f5772bf1f1d80cc16f30c80915d9e5622ad0637daf5b5dff29308ad5fc68b62L1232-R1238)
* The frontend server (`frontend_server.py`) now includes an API proxy route (`/api/{full_path:path}`), forwarding API requests to the backend API using the `BACKEND_API_URL` environment variable. This ensures all API traffic passes through the frontend, supporting both internal and external networking scenarios. [[1]](diffhunk://#diff-163320c83714f7af2dd9c8332e03a952c7ec5418861fe4202b3d1fe471de49a3R3-R17) [[2]](diffhunk://#diff-163320c83714f7af2dd9c8332e03a952c7ec5418861fe4202b3d1fe471de49a3R78-R114)
* Added `httpx` as a dependency to support asynchronous HTTP proxying in the frontend server.## Purpose
<!-- Describe the intention of the changes being proposed. What problem does it solve or functionality does it add? -->
* ...

## Does this introduce a breaking change?
<!-- Mark one with an "x". -->

- [ ] Yes
- [x] No

<!-- Please prefix your PR title with one of the following:
  * `feat`: A new feature
  * `fix`: A bug fix
  * `docs`: Documentation only changes
  * `style`: Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc)
  * `refactor`: A code change that neither fixes a bug nor adds a feature
  * `perf`: A code change that improves performance
  * `test`: Adding missing tests or correcting existing tests
  * `build`: Changes that affect the build system or external dependencies (example scopes: gulp, broccoli, npm)
  * `ci`: Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
  * `chore`: Other changes that don't modify src or test files
  * `revert`: Reverts a previous commit
  * !: A breaking change is indicated with a `!` after the listed prefixes above, e.g. `feat!`, `fix!`, `refactor!`, etc.
-->

## Golden Path Validation
- [x] I have tested the primary workflows (the "golden path") to ensure they function correctly without errors.

## Deployment Validation
- [x] I have validated the deployment process successfully and all services are running as expected with this change.

## What to Check
Verify that the following are valid
* ...

## Other Information

<!-- Add any other helpful information that may be needed here. -->
