### PR TITLE
chore: Refactor location parameter usage in main.bicep

### DIFF
--- a/infra/main.bicep
+++ b/infra/main.bicep
@@ -11,9 +11,8 @@ param solutionUniqueText string = substring(uniqueString(subscription().id, reso
 
 @minLength(3)
 @metadata({ azd: { type: 'location' } })
-@description('Required. Azure region for container apps, storage, and other services. Choose a region close to your users.')
+@description('Required. Azure region for container apps, storage, Cosmos DB, and other services. Choose a region close to your users.')
 param location string
-var solutionLocation = empty(location) ? resourceGroup().location : location
 
 @allowed([
   'australiaeast'
@@ -38,23 +37,6 @@ var solutionLocation = empty(location) ? resourceGroup().location : location
 })
 @description('Required. Azure region for AI services (OpenAI/AI Foundry). Must be a region that supports gpt-5.1 model deployment.')
 param azureAiServiceLocation string
-
-@allowed([
-  'australiaeast'
-  'eastus'
-  'eastus2'
-  'francecentral'
-  'japaneast'
-  'norwayeast'
-  'southindia'
-  'swedencentral'
-  'uksouth'
-  'westus'
-  'westus3'
-])
-@description('Required. Azure region for AI model deployment. Should match azureAiServiceLocation for optimal performance.')
-#disable-next-line no-unused-params
-param aiDeploymentLocation string = azureAiServiceLocation
 
 @description('Optional. The host (excluding https://) of an existing container registry. This is the `loginServer` when using Azure Container Registry.')
 param containerRegistryHost string = 'containermigrationacr.azurecr.io'
@@ -110,9 +92,6 @@ param enableMonitoring bool = false
 
 @description('Optional. Enable scalability for applicable resources, aligned with the Well Architected Framework recommendations. Defaults to false.')
 param enableScalability bool = false
-
-@description('Optional. CosmosDB Location')
-param cosmosLocation string = 'eastus2'
 
 @description('Optional. Existing Log Analytics Workspace Resource ID')
 param existingLogAnalyticsWorkspaceId string = ''
@@ -229,7 +208,7 @@ module appIdentity 'br/public:avm/res/managed-identity/user-assigned-identity:0.
   name: take('avm.res.managed-identity.user-assigned-identity.${userAssignedIdentityResourceName}', 64)
   params: {
     name: userAssignedIdentityResourceName
-    location: solutionLocation
+    location: location
     tags: allTags
     enableTelemetry: enableTelemetry
   }
@@ -243,7 +222,7 @@ module logAnalyticsWorkspace 'br/public:avm/res/operational-insights/workspace:0
   name: take('avm.res.operational-insights.workspace.${logAnalyticsWorkspaceResourceName}', 64)
   params: {
     name: logAnalyticsWorkspaceResourceName
-    location: solutionLocation
+    location: location
     skuName: 'PerGB2018'
     dataRetention: 30
     diagnosticSettings: [{ useThisWorkspace: true }]
@@ -308,7 +287,7 @@ module applicationInsights 'br/public:avm/res/insights/component:0.6.0' = if (en
   //dependsOn: [logAnalyticsWorkspace]
   params: {
     name: applicationInsightsResourceName
-    location: solutionLocation
+    location: location
     tags: allTags
     enableTelemetry: enableTelemetry
     retentionInDays: 365
@@ -492,7 +471,7 @@ module storageAccount 'br/public:avm/res/storage/storage-account:0.20.0' = {
   name: take('avm.res.storage.storage-account.${storageAccountName}', 64)
   params: {
     name: storageAccountName
-    location: solutionLocation
+    location: location
     managedIdentities: { systemAssigned: true }
     minimumTlsVersion: 'TLS1_2'
     enableTelemetry: enableTelemetry
@@ -610,7 +589,7 @@ module cosmosDb 'br/public:avm/res/document-db/database-account:0.15.0' = {
   name: take('avm.res.document-db.database-account.${cosmosDbResourceName}', 64)
   params: {
     name: cosmosDbResourceName
-    location: cosmosLocation
+    location: location
     tags: allTags
     enableTelemetry: enableTelemetry
     sqlDatabases: [
@@ -692,7 +671,7 @@ module cosmosDb 'br/public:avm/res/document-db/database-account:0.15.0' = {
           {
             failoverPriority: 0
             isZoneRedundant: true
-            locationName: solutionLocation
+            locationName: location
           }
           {
             failoverPriority: 1
@@ -702,7 +681,7 @@ module cosmosDb 'br/public:avm/res/document-db/database-account:0.15.0' = {
         ]
       : [
           {
-            locationName: solutionLocation
+            locationName: location
             failoverPriority: 0
             isZoneRedundant: enableRedundancy
           }
@@ -918,7 +897,7 @@ module aiFoundryPrivateEndpoint 'br/public:avm/res/network/private-endpoint:0.8.
   params: {
     name: 'pep-${aiFoundryAiServicesResourceName}'
     customNetworkInterfaceName: 'nic-${aiFoundryAiServicesResourceName}'
-    location: solutionLocation
+    location: location
     tags: allTags
     enableTelemetry: enableTelemetry
     privateLinkServiceConnections: [
@@ -968,7 +947,7 @@ var aiServicesName = useExistingAiFoundryAiProject ? existingAiFoundryAiServices
 module appConfiguration 'br/public:avm/res/app-configuration/configuration-store:0.9.1' = {
   name: take('avm.res.app-config.store.${solutionSuffix}', 64)
   params: {
-    location: solutionLocation
+    location: location
     name: 'appcs-${solutionSuffix}'
     disableLocalAuth: false // needed to allow setting app config key values from this module
     tags: allTags
@@ -1096,7 +1075,7 @@ module avmAppConfigUpdated 'br/public:avm/res/app-configuration/configuration-st
   name: take('avm.res.app-configuration.configuration-store-update.${solutionSuffix}', 64)
   params: {
     name: 'appcs-${solutionSuffix}'
-    location: solutionLocation
+    location: location
     managedIdentities: { systemAssigned: true }
     sku: 'Standard'
     enableTelemetry: enableTelemetry
@@ -1177,7 +1156,7 @@ module containerAppBackend 'br/public:avm/res/app/container-app:0.18.1' = {
   dependsOn: [applicationInsights]
   params: {
     name: backendContainerAppName
-    location: solutionLocation
+    location: location
     environmentResourceId: containerAppsEnvironment.outputs.resourceId
     managedIdentities: {
       userAssignedResourceIds: [
@@ -1264,7 +1243,7 @@ module containerAppFrontend 'br/public:avm/res/app/container-app:0.18.1' = {
   name: take('avm.res.app.container-app.${frontEndContainerAppName}', 64)
   params: {
     name: frontEndContainerAppName
-    location: solutionLocation
+    location: location
     environmentResourceId: containerAppsEnvironment.outputs.resourceId
     managedIdentities: {
       userAssignedResourceIds: [
@@ -1332,7 +1311,7 @@ module containerAppProcessor 'br/public:avm/res/app/container-app:0.18.1' = {
   dependsOn: [applicationInsights]
   params: {
     name: processorContainerAppName
-    location: solutionLocation
+    location: location
     environmentResourceId: containerAppsEnvironment.outputs.resourceId
     managedIdentities: {
       userAssignedResourceIds: [

--- a/infra/main.json
+++ b/infra/main.json
@@ -5,8 +5,8 @@
   "metadata": {
     "_generator": {
       "name": "bicep",
-      "version": "0.42.1.51946",
-      "templateHash": "11219559543155133570"
+      "version": "0.36.177.2456",
+      "templateHash": "6661423266739154339"
     }
   },
   "parameters": {
@@ -32,7 +32,7 @@
         "azd": {
           "type": "location"
         },
-        "description": "Required. Azure region for container apps, storage, and other services. Choose a region close to your users."
+        "description": "Required. Azure region for container apps, storage, Cosmos DB, and other services. Choose a region close to your users."
       },
       "minLength": 3
     },
@@ -59,26 +59,6 @@
           ]
         },
         "description": "Required. Azure region for AI services (OpenAI/AI Foundry). Must be a region that supports gpt-5.1 model deployment."
-      }
-    },
-    "aiDeploymentLocation": {
-      "type": "string",
-      "defaultValue": "[parameters('azureAiServiceLocation')]",
-      "allowedValues": [
-        "australiaeast",
-        "eastus",
-        "eastus2",
-        "francecentral",
-        "japaneast",
-        "norwayeast",
-        "southindia",
-        "swedencentral",
-        "uksouth",
-        "westus",
-        "westus3"
-      ],
-      "metadata": {
-        "description": "Required. Azure region for AI model deployment. Should match azureAiServiceLocation for optimal performance."
       }
     },
     "containerRegistryHost": {
@@ -209,13 +189,6 @@
         "description": "Optional. Enable scalability for applicable resources, aligned with the Well Architected Framework recommendations. Defaults to false."
       }
     },
-    "cosmosLocation": {
-      "type": "string",
-      "defaultValue": "eastus2",
-      "metadata": {
-        "description": "Optional. CosmosDB Location"
-      }
-    },
     "existingLogAnalyticsWorkspaceId": {
       "type": "string",
       "defaultValue": "",
@@ -260,7 +233,6 @@
     }
   },
   "variables": {
-    "solutionLocation": "[if(empty(parameters('location')), resourceGroup().location, parameters('location'))]",
     "deployerInfo": "[deployer()]",
     "deployingUserPrincipalId": "[variables('deployerInfo').objectId]",
     "deployingUserType": "[if(contains(variables('deployerInfo'), 'userPrincipalName'), 'User', 'ServicePrincipal')]",
@@ -346,8 +318,8 @@
     "aiServicesName": "[if(variables('useExistingAiFoundryAiProject'), variables('aiFoundryAiServicesResourceName'), variables('aiFoundryAiServicesResourceName'))]",
     "backendContainerPort": 80,
     "backendContainerAppName": "[take(format('ca-backend-api-{0}', variables('solutionSuffix')), 32)]",
-    "frontEndContainerAppName": "[take(format('ca-frontend-{0}', variables('solutionSuffix')), 32)]",
-    "processorContainerAppName": "[take(format('ca-processor-{0}', variables('solutionSuffix')), 32)]"
+    "processorContainerAppName": "[take(format('ca-processor-{0}', variables('solutionSuffix')), 32)]",
+    "frontEndContainerAppName": "[take(format('ca-frontend-{0}', variables('solutionSuffix')), 32)]"
   },
   "resources": {
     "existingLogAnalyticsWorkspace": {
@@ -378,7 +350,7 @@
     },
     "appIdentity": {
       "type": "Microsoft.Resources/deployments",
-      "apiVersion": "2025-04-01",
+      "apiVersion": "2022-09-01",
       "name": "[take(format('avm.res.managed-identity.user-assigned-identity.{0}', variables('userAssignedIdentityResourceName')), 64)]",
       "properties": {
         "expressionEvaluationOptions": {
@@ -390,7 +362,7 @@
             "value": "[variables('userAssignedIdentityResourceName')]"
           },
           "location": {
-            "value": "[variables('solutionLocation')]"
+            "value": "[parameters('location')]"
           },
           "tags": {
             "value": "[variables('allTags')]"
@@ -861,7 +833,7 @@
     "logAnalyticsWorkspace": {
       "condition": "[and(or(parameters('enableMonitoring'), parameters('enablePrivateNetworking')), not(variables('useExistingLogAnalytics')))]",
       "type": "Microsoft.Resources/deployments",
-      "apiVersion": "2025-04-01",
+      "apiVersion": "2022-09-01",
       "name": "[take(format('avm.res.operational-insights.workspace.{0}', variables('logAnalyticsWorkspaceResourceName')), 64)]",
       "properties": {
         "expressionEvaluationOptions": {
@@ -873,7 +845,7 @@
             "value": "[variables('logAnalyticsWorkspaceResourceName')]"
           },
           "location": {
-            "value": "[variables('solutionLocation')]"
+            "value": "[parameters('location')]"
           },
           "skuName": {
             "value": "PerGB2018"
@@ -3967,7 +3939,7 @@
     "applicationInsights": {
       "condition": "[parameters('enableMonitoring')]",
       "type": "Microsoft.Resources/deployments",
-      "apiVersion": "2025-04-01",
+      "apiVersion": "2022-09-01",
       "name": "[take(format('avm.res.insights.component.{0}', variables('applicationInsightsResourceName')), 64)]",
       "properties": {
         "expressionEvaluationOptions": {
@@ -3979,7 +3951,7 @@
             "value": "[variables('applicationInsightsResourceName')]"
           },
           "location": {
-            "value": "[variables('solutionLocation')]"
+            "value": "[parameters('location')]"
           },
           "tags": {
             "value": "[variables('allTags')]"
@@ -4698,7 +4670,7 @@
     "virtualNetwork": {
       "condition": "[parameters('enablePrivateNetworking')]",
       "type": "Microsoft.Resources/deployments",
-      "apiVersion": "2025-04-01",
+      "apiVersion": "2022-09-01",
       "name": "[take(format('module.virtual-network.{0}', variables('solutionSuffix')), 64)]",
       "properties": {
         "expressionEvaluationOptions": {
@@ -4735,8 +4707,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.42.1.51946",
-              "templateHash": "2245351167779444314"
+              "version": "0.36.177.2456",
+              "templateHash": "14325184480475687154"
             }
           },
           "definitions": {
@@ -5180,7 +5152,7 @@
               },
               "condition": "[not(empty(tryGet(parameters('subnets')[copyIndex()], 'networkSecurityGroup')))]",
               "type": "Microsoft.Resources/deployments",
-              "apiVersion": "2025-04-01",
+              "apiVersion": "2022-09-01",
               "name": "[take(format('avm.res.network.network-security-group.{0}.{1}', tryGet(parameters('subnets')[copyIndex()], 'networkSecurityGroup', 'name'), parameters('resourceSuffix')), 64)]",
               "properties": {
                 "expressionEvaluationOptions": {
@@ -5832,7 +5804,7 @@
             },
             "virtualNetwork": {
               "type": "Microsoft.Resources/deployments",
-              "apiVersion": "2025-04-01",
+              "apiVersion": "2022-09-01",
               "name": "[take(format('avm.res.network.virtual-network.{0}', parameters('name')), 64)]",
               "properties": {
                 "expressionEvaluationOptions": {
@@ -7559,7 +7531,7 @@
     "bastionHost": {
       "condition": "[parameters('enablePrivateNetworking')]",
       "type": "Microsoft.Resources/deployments",
-      "apiVersion": "2025-04-01",
+      "apiVersion": "2022-09-01",
       "name": "[take(format('avm.res.network.bastion-host.{0}', variables('bastionHostName')), 64)]",
       "properties": {
         "expressionEvaluationOptions": {
@@ -8865,7 +8837,7 @@
     "jumpboxVM": {
       "condition": "[parameters('enablePrivateNetworking')]",
       "type": "Microsoft.Resources/deployments",
-      "apiVersion": "2025-04-01",
+      "apiVersion": "2022-09-01",
       "name": "[take(format('avm.res.compute.virtual-machine.{0}', variables('jumpboxVmName')), 64)]",
       "properties": {
         "expressionEvaluationOptions": {
@@ -17198,7 +17170,7 @@
       },
       "condition": "[and(parameters('enablePrivateNetworking'), or(empty(parameters('existingFoundryProjectResourceId')), not(contains(variables('aiRelatedDnsZoneIndices'), copyIndex()))))]",
       "type": "Microsoft.Resources/deployments",
-      "apiVersion": "2025-04-01",
+      "apiVersion": "2022-09-01",
       "name": "[format('dns-zone-{0}', copyIndex())]",
       "properties": {
         "expressionEvaluationOptions": {
@@ -20365,7 +20337,7 @@
     },
     "storageAccount": {
       "type": "Microsoft.Resources/deployments",
-      "apiVersion": "2025-04-01",
+      "apiVersion": "2022-09-01",
       "name": "[take(format('avm.res.storage.storage-account.{0}', variables('storageAccountName')), 64)]",
       "properties": {
         "expressionEvaluationOptions": {
@@ -20377,7 +20349,7 @@
             "value": "[variables('storageAccountName')]"
           },
           "location": {
-            "value": "[variables('solutionLocation')]"
+            "value": "[parameters('location')]"
           },
           "managedIdentities": {
             "value": {
@@ -26162,7 +26134,7 @@
     },
     "cosmosDb": {
       "type": "Microsoft.Resources/deployments",
-      "apiVersion": "2025-04-01",
+      "apiVersion": "2022-09-01",
       "name": "[take(format('avm.res.document-db.database-account.{0}', variables('cosmosDbResourceName')), 64)]",
       "properties": {
         "expressionEvaluationOptions": {
@@ -26174,7 +26146,7 @@
             "value": "[variables('cosmosDbResourceName')]"
           },
           "location": {
-            "value": "[parameters('cosmosLocation')]"
+            "value": "[parameters('location')]"
           },
           "tags": {
             "value": "[variables('allTags')]"
@@ -26232,7 +26204,7 @@
           "zoneRedundant": "[if(parameters('enableRedundancy'), createObject('value', true()), createObject('value', false()))]",
           "capabilitiesToAdd": "[if(parameters('enableRedundancy'), createObject('value', null()), createObject('value', createArray('EnableServerless')))]",
           "automaticFailover": "[if(parameters('enableRedundancy'), createObject('value', true()), createObject('value', false()))]",
-          "failoverLocations": "[if(parameters('enableRedundancy'), createObject('value', createArray(createObject('failoverPriority', 0, 'isZoneRedundant', true(), 'locationName', variables('solutionLocation')), createObject('failoverPriority', 1, 'isZoneRedundant', true(), 'locationName', variables('cosmosDbHaLocation')))), createObject('value', createArray(createObject('locationName', variables('solutionLocation'), 'failoverPriority', 0, 'isZoneRedundant', parameters('enableRedundancy')))))]",
+          "failoverLocations": "[if(parameters('enableRedundancy'), createObject('value', createArray(createObject('failoverPriority', 0, 'isZoneRedundant', true(), 'locationName', parameters('location')), createObject('failoverPriority', 1, 'isZoneRedundant', true(), 'locationName', variables('cosmosDbHaLocation')))), createObject('value', createArray(createObject('locationName', parameters('location'), 'failoverPriority', 0, 'isZoneRedundant', parameters('enableRedundancy')))))]",
           "roleAssignments": {
             "value": [
               {
@@ -30045,7 +30017,7 @@
     "existingAiFoundryAiServicesDeployments": {
       "condition": "[variables('useExistingAiFoundryAiProject')]",
       "type": "Microsoft.Resources/deployments",
-      "apiVersion": "2025-04-01",
+      "apiVersion": "2022-09-01",
       "name": "[take(format('module.ai-services-model-deployments.{0}', variables('aiFoundryAiServicesResourceName')), 64)]",
       "subscriptionId": "[variables('aiFoundryAiServicesSubscriptionId')]",
       "resourceGroup": "[variables('aiFoundryAiServicesResourceGroupName')]",
@@ -30123,8 +30095,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.42.1.51946",
-              "templateHash": "16866311185741009453"
+              "version": "0.36.177.2456",
+              "templateHash": "15406919741214273256"
             }
           },
           "definitions": {
@@ -30431,7 +30403,7 @@
               },
               "type": "Microsoft.Authorization/roleAssignments",
               "apiVersion": "2022-04-01",
-              "scope": "[resourceId('Microsoft.CognitiveServices/accounts', parameters('name'))]",
+              "scope": "[format('Microsoft.CognitiveServices/accounts/{0}', parameters('name'))]",
               "name": "[coalesce(tryGet(coalesce(variables('formattedRoleAssignments'), createArray())[copyIndex()], 'name'), guid(resourceId('Microsoft.CognitiveServices/accounts', parameters('name')), coalesce(variables('formattedRoleAssignments'), createArray())[copyIndex()].principalId, coalesce(variables('formattedRoleAssignments'), createArray())[copyIndex()].roleDefinitionId))]",
               "properties": {
                 "roleDefinitionId": "[coalesce(variables('formattedRoleAssignments'), createArray())[copyIndex()].roleDefinitionId]",
@@ -30453,7 +30425,7 @@
     "aiFoundryAiServices": {
       "condition": "[not(variables('useExistingAiFoundryAiProject'))]",
       "type": "Microsoft.Resources/deployments",
-      "apiVersion": "2025-04-01",
+      "apiVersion": "2022-09-01",
       "name": "[take(format('avm.res.cognitive-services.account.{0}', variables('aiFoundryAiServicesResourceName')), 64)]",
       "properties": {
         "expressionEvaluationOptions": {
@@ -33103,7 +33075,7 @@
     "aiFoundryPrivateEndpoint": {
       "condition": "[and(parameters('enablePrivateNetworking'), not(variables('useExistingAiFoundryAiProject')))]",
       "type": "Microsoft.Resources/deployments",
-      "apiVersion": "2025-04-01",
+      "apiVersion": "2022-09-01",
       "name": "[take(format('pep-{0}-deployment', variables('aiFoundryAiServicesResourceName')), 64)]",
       "properties": {
         "expressionEvaluationOptions": {
@@ -33118,7 +33090,7 @@
             "value": "[format('nic-{0}', variables('aiFoundryAiServicesResourceName'))]"
           },
           "location": {
-            "value": "[variables('solutionLocation')]"
+            "value": "[parameters('location')]"
           },
           "tags": {
             "value": "[variables('allTags')]"
@@ -33873,8 +33845,8 @@
       },
       "dependsOn": [
         "aiFoundryAiServices",
-        "[format('avmPrivateDnsZones[{0}]', variables('dnsZoneIndex').cognitiveServices)]",
         "[format('avmPrivateDnsZones[{0}]', variables('dnsZoneIndex').aiServices)]",
+        "[format('avmPrivateDnsZones[{0}]', variables('dnsZoneIndex').cognitiveServices)]",
         "[format('avmPrivateDnsZones[{0}]', variables('dnsZoneIndex').openAI)]",
         "virtualNetwork"
       ]
@@ -33882,7 +33854,7 @@
     "aiFoundryProject": {
       "condition": "[not(variables('useExistingAiFoundryAiProject'))]",
       "type": "Microsoft.Resources/deployments",
-      "apiVersion": "2025-04-01",
+      "apiVersion": "2022-09-01",
       "name": "[take(format('module.ai-project.{0}', variables('aiFoundryAiProjectResourceName')), 64)]",
       "properties": {
         "expressionEvaluationOptions": {
@@ -33912,8 +33884,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.42.1.51946",
-              "templateHash": "16351752584270870112"
+              "version": "0.36.177.2456",
+              "templateHash": "9521962578302996488"
             }
           },
           "parameters": {
@@ -34006,7 +33978,7 @@
     },
     "appConfiguration": {
       "type": "Microsoft.Resources/deployments",
-      "apiVersion": "2025-04-01",
+      "apiVersion": "2022-09-01",
       "name": "[take(format('avm.res.app-config.store.{0}', variables('solutionSuffix')), 64)]",
       "properties": {
         "expressionEvaluationOptions": {
@@ -34015,7 +33987,7 @@
         "mode": "Incremental",
         "parameters": {
           "location": {
-            "value": "[variables('solutionLocation')]"
+            "value": "[parameters('location')]"
           },
           "name": {
             "value": "[format('appcs-{0}', variables('solutionSuffix'))]"
@@ -36351,7 +36323,7 @@
     "avmAppConfigUpdated": {
       "condition": "[parameters('enablePrivateNetworking')]",
       "type": "Microsoft.Resources/deployments",
-      "apiVersion": "2025-04-01",
+      "apiVersion": "2022-09-01",
       "name": "[take(format('avm.res.app-configuration.configuration-store-update.{0}', variables('solutionSuffix')), 64)]",
       "properties": {
         "expressionEvaluationOptions": {
@@ -36363,7 +36335,7 @@
             "value": "[format('appcs-{0}', variables('solutionSuffix'))]"
           },
           "location": {
-            "value": "[variables('solutionLocation')]"
+            "value": "[parameters('location')]"
           },
           "managedIdentities": {
             "value": {
@@ -38368,7 +38340,7 @@
     },
     "containerAppsEnvironment": {
       "type": "Microsoft.Resources/deployments",
-      "apiVersion": "2025-04-01",
+      "apiVersion": "2022-09-01",
       "name": "[take(format('avm.res.app.managed-environment.{0}', variables('solutionSuffix')), 64)]",
       "properties": {
         "expressionEvaluationOptions": {
@@ -38387,7 +38359,7 @@
               "systemAssigned": true
             }
           },
-          "appLogsConfiguration": "[if(parameters('enableMonitoring'), createObject('value', createObject('destination', 'log-analytics', 'logAnalyticsConfiguration', createObject('customerId', if(variables('useExistingLogAnalytics'), reference('existingLogAnalyticsWorkspace').customerId, reference('logAnalyticsWorkspace').outputs.logAnalyticsWorkspaceId.value), 'sharedKey', if(variables('useExistingLogAnalytics'), listKeys('existingLogAnalyticsWorkspace', '2020-08-01').primarySharedKey, listOutputsWithSecureValues('logAnalyticsWorkspace', '2025-04-01').primarySharedKey)))), createObject('value', null()))]",
+          "appLogsConfiguration": "[if(parameters('enableMonitoring'), createObject('value', createObject('destination', 'log-analytics', 'logAnalyticsConfiguration', createObject('customerId', if(variables('useExistingLogAnalytics'), reference('existingLogAnalyticsWorkspace').customerId, reference('logAnalyticsWorkspace').outputs.logAnalyticsWorkspaceId.value), 'sharedKey', if(variables('useExistingLogAnalytics'), listKeys('existingLogAnalyticsWorkspace', '2020-08-01').primarySharedKey, listOutputsWithSecureValues('logAnalyticsWorkspace', '2022-09-01').primarySharedKey)))), createObject('value', null()))]",
           "workloadProfiles": {
             "value": [
               {
@@ -39289,7 +39261,7 @@
     },
     "containerAppBackend": {
       "type": "Microsoft.Resources/deployments",
-      "apiVersion": "2025-04-01",
+      "apiVersion": "2022-09-01",
       "name": "[take(format('avm.res.app.container-app.{0}', variables('backendContainerAppName')), 64)]",
       "properties": {
         "expressionEvaluationOptions": {
@@ -39301,7 +39273,7 @@
             "value": "[variables('backendContainerAppName')]"
           },
           "location": {
-            "value": "[variables('solutionLocation')]"
+            "value": "[parameters('location')]"
           },
           "environmentResourceId": {
             "value": "[reference('containerAppsEnvironment').outputs.resourceId.value]"
@@ -39318,7 +39290,7 @@
               {
                 "name": "backend-api",
                 "image": "[format('{0}/backend-api:{1}', parameters('containerRegistryHost'), parameters('imageTag'))]",
-                "env": "[concat(createArray(createObject('name', 'APP_CONFIGURATION_URL', 'value', reference('appConfiguration').outputs.endpoint.value), createObject('name', 'AZURE_CLIENT_ID', 'value', reference('appIdentity').outputs.clientId.value)), if(parameters('enableMonitoring'), createArray(createObject('name', 'APPLICATIONINSIGHTS_CONNECTION_STRING', 'value', reference('applicationInsights').outputs.connectionString.value)), createArray()))]",
+                "env": "[concat(createArray(createObject('name', 'APP_CONFIGURATION_URL', 'value', reference('appConfiguration').outputs.endpoint.value), createObject('name', 'AZURE_CLIENT_ID', 'value', reference('appIdentity').outputs.clientId.value), createObject('name', 'PROCESSOR_CONTROL_URL', 'value', format('https://{0}.internal.{1}', variables('processorContainerAppName'), reference('containerAppsEnvironment').outputs.defaultDomain.value))), if(parameters('enableMonitoring'), createArray(createObject('name', 'APPLICATIONINSIGHTS_CONNECTION_STRING', 'value', reference('applicationInsights').outputs.connectionString.value)), createArray()))]",
                 "resources": {
                   "cpu": 1,
                   "memory": "2.0Gi"
@@ -40936,7 +40908,7 @@
     },
     "containerAppFrontend": {
       "type": "Microsoft.Resources/deployments",
-      "apiVersion": "2025-04-01",
+      "apiVersion": "2022-09-01",
       "name": "[take(format('avm.res.app.container-app.{0}', variables('frontEndContainerAppName')), 64)]",
       "properties": {
         "expressionEvaluationOptions": {
@@ -40948,7 +40920,7 @@
             "value": "[variables('frontEndContainerAppName')]"
           },
           "location": {
-            "value": "[variables('solutionLocation')]"
+            "value": "[parameters('location')]"
           },
           "environmentResourceId": {
             "value": "[reference('containerAppsEnvironment').outputs.resourceId.value]"
@@ -42584,7 +42556,7 @@
     },
     "containerAppProcessor": {
       "type": "Microsoft.Resources/deployments",
-      "apiVersion": "2025-04-01",
+      "apiVersion": "2022-09-01",
       "name": "[take(format('avm.res.app.container-app.{0}', variables('processorContainerAppName')), 64)]",
       "properties": {
         "expressionEvaluationOptions": {
@@ -42596,7 +42568,7 @@
             "value": "[variables('processorContainerAppName')]"
           },
           "location": {
-            "value": "[variables('solutionLocation')]"
+            "value": "[parameters('location')]"
           },
           "environmentResourceId": {
             "value": "[reference('containerAppsEnvironment').outputs.resourceId.value]"
@@ -42613,7 +42585,7 @@
               {
                 "name": "processor",
                 "image": "[format('{0}/processor:{1}', parameters('containerRegistryHost'), parameters('imageTag'))]",
-                "env": "[concat(createArray(createObject('name', 'APP_CONFIGURATION_URL', 'value', reference('appConfiguration').outputs.endpoint.value), createObject('name', 'AZURE_CLIENT_ID', 'value', reference('appIdentity').outputs.clientId.value), createObject('name', 'AZURE_STORAGE_ACCOUNT_NAME', 'value', reference('storageAccount').outputs.name.value), createObject('name', 'STORAGE_ACCOUNT_NAME', 'value', reference('storageAccount').outputs.name.value)), if(parameters('enableMonitoring'), createArray(createObject('name', 'APPLICATIONINSIGHTS_CONNECTION_STRING', 'value', reference('applicationInsights').outputs.connectionString.value)), createArray()))]",
+                "env": "[concat(createArray(createObject('name', 'APP_CONFIGURATION_URL', 'value', reference('appConfiguration').outputs.endpoint.value), createObject('name', 'AZURE_CLIENT_ID', 'value', reference('appIdentity').outputs.clientId.value), createObject('name', 'AZURE_STORAGE_ACCOUNT_NAME', 'value', reference('storageAccount').outputs.name.value), createObject('name', 'STORAGE_ACCOUNT_NAME', 'value', reference('storageAccount').outputs.name.value), createObject('name', 'CONTROL_API_ENABLED', 'value', '1'), createObject('name', 'CONTROL_API_PORT', 'value', '8080')), if(parameters('enableMonitoring'), createArray(createObject('name', 'APPLICATIONINSIGHTS_CONNECTION_STRING', 'value', reference('applicationInsights').outputs.connectionString.value)), createArray()))]",
                 "resources": {
                   "cpu": 2,
                   "memory": "4.0Gi"
@@ -42621,14 +42593,14 @@
               }
             ]
           },
-          "ingressTransport": {
-            "value": null
-          },
-          "disableIngress": {
-            "value": true
+          "ingressTargetPort": {
+            "value": 8080
           },
           "ingressExternal": {
             "value": false
+          },
+          "ingressAllowInsecure": {
+            "value": true
           },
           "scaleSettings": {
             "value": {

--- a/infra/main.parameters.json
+++ b/infra/main.parameters.json
@@ -14,12 +14,6 @@
       "azureAiServiceLocation": {
         "value": "${AZURE_AI_SERVICE_LOCATION}"
       },
-      "aiDeploymentLocation": {
-        "value": "${AZURE_AI_DEPLOYMENT_LOCATION}"
-      },
-      "azureAiServiceLocation": {
-        "value": "${AZURE_AI_SERVICE_LOCATION}"
-      },
       "aiDeploymentType": {
         "value": "${AZURE_AI_DEPLOYMENT_TYPE}"
       },

--- a/infra/main.waf.parameters.json
+++ b/infra/main.waf.parameters.json
@@ -14,12 +14,6 @@
       "azureAiServiceLocation": {
         "value": "${AZURE_AI_SERVICE_LOCATION}"
       },
-      "aiDeploymentLocation": {
-        "value": "${AZURE_AI_DEPLOYMENT_LOCATION}"
-      },
-      "azureAiServiceLocation": {
-        "value": "${AZURE_AI_SERVICE_LOCATION}"
-      },
       "aiDeploymentType": {
         "value": "${AZURE_AI_DEPLOYMENT_TYPE}"
       },

--- a/infra/main_custom.bicep
+++ b/infra/main_custom.bicep
@@ -13,7 +13,6 @@ param solutionUniqueText string = substring(uniqueString(subscription().id, reso
 @metadata({ azd: { type: 'location' } })
 @description('Required. Azure region for container apps, storage, and other services. Choose a region close to your users.')
 param location string
-var solutionLocation = empty(location) ? resourceGroup().location : location
 
 @allowed([
   'australiaeast'
@@ -88,9 +87,6 @@ param enableMonitoring bool = false
 
 @description('Optional. Enable scalability for applicable resources, aligned with the Well Architected Framework recommendations. Defaults to false.')
 param enableScalability bool = false
-
-@description('Optional. CosmosDB Location')
-param cosmosLocation string = 'eastus2'
 
 @description('Optional. Existing Log Analytics Workspace Resource ID')
 param existingLogAnalyticsWorkspaceId string = ''
@@ -192,7 +188,7 @@ module appIdentity 'br/public:avm/res/managed-identity/user-assigned-identity:0.
   name: take('avm.res.managed-identity.user-assigned-identity.${userAssignedIdentityResourceName}', 64)
   params: {
     name: userAssignedIdentityResourceName
-    location: solutionLocation
+    location: location
     tags: allTags
     enableTelemetry: enableTelemetry
   }
@@ -206,7 +202,7 @@ module logAnalyticsWorkspace 'br/public:avm/res/operational-insights/workspace:0
   name: take('avm.res.operational-insights.workspace.${logAnalyticsWorkspaceResourceName}', 64)
   params: {
     name: logAnalyticsWorkspaceResourceName
-    location: solutionLocation
+    location: location
     skuName: 'PerGB2018'
     dataRetention: 30
     diagnosticSettings: [{ useThisWorkspace: true }]
@@ -271,7 +267,7 @@ module applicationInsights 'br/public:avm/res/insights/component:0.6.0' = if (en
   //dependsOn: [logAnalyticsWorkspace]
   params: {
     name: applicationInsightsResourceName
-    location: solutionLocation
+    location: location
     tags: allTags
     enableTelemetry: enableTelemetry
     retentionInDays: 365
@@ -455,7 +451,7 @@ module storageAccount 'br/public:avm/res/storage/storage-account:0.20.0' = {
   name: take('avm.res.storage.storage-account.${storageAccountName}', 64)
   params: {
     name: storageAccountName
-    location: solutionLocation
+    location: location
     managedIdentities: { systemAssigned: true }
     minimumTlsVersion: 'TLS1_2'
     enableTelemetry: enableTelemetry
@@ -560,7 +556,7 @@ module cosmosDb 'br/public:avm/res/document-db/database-account:0.15.0' = {
   name: take('avm.res.document-db.database-account.${cosmosDbResourceName}', 64)
   params: {
     name: cosmosDbResourceName
-    location: cosmosLocation
+    location: location
     tags: allTags
     enableTelemetry: enableTelemetry
     sqlDatabases: [
@@ -636,7 +632,7 @@ module cosmosDb 'br/public:avm/res/document-db/database-account:0.15.0' = {
           {
             failoverPriority: 0
             isZoneRedundant: true
-            locationName: solutionLocation
+            locationName: location
           }
           {
             failoverPriority: 1
@@ -646,7 +642,7 @@ module cosmosDb 'br/public:avm/res/document-db/database-account:0.15.0' = {
         ]
       : [
           {
-            locationName: solutionLocation
+            locationName: location
             failoverPriority: 0
             isZoneRedundant: enableRedundancy
           }
@@ -692,7 +688,7 @@ module containerRegistry 'br/public:avm/res/container-registry/registry:0.9.1' =
     acrSku: 'Basic'
     azureADAuthenticationAsArmPolicyStatus: 'enabled'
     exportPolicyStatus: 'enabled'
-    location: solutionLocation
+    location: location
     softDeletePolicyDays: 7
     softDeletePolicyStatus: 'disabled'
     tags: allTags
@@ -845,7 +841,7 @@ module aiFoundryPrivateEndpoint 'br/public:avm/res/network/private-endpoint:0.8.
   params: {
     name: 'pep-${aiFoundryAiServicesResourceName}'
     customNetworkInterfaceName: 'nic-${aiFoundryAiServicesResourceName}'
-    location: solutionLocation
+    location: location
     tags: allTags
     enableTelemetry: enableTelemetry
     privateLinkServiceConnections: [
@@ -917,7 +913,7 @@ var aiServicesName = useExistingAiFoundryAiProject ? existingAiFoundryAiServices
 module appConfiguration 'br/public:avm/res/app-configuration/configuration-store:0.9.1' = {
   name: take('avm.res.app-config.store.${solutionSuffix}', 64)
   params: {
-    location: solutionLocation
+    location: location
     name: 'appcs-${solutionSuffix}'
     disableLocalAuth: false // needed to allow setting app config key values from this module
     tags: allTags
@@ -1034,7 +1030,7 @@ module avmAppConfigUpdated 'br/public:avm/res/app-configuration/configuration-st
   name: take('avm.res.app-configuration.configuration-store-update.${solutionSuffix}', 64)
   params: {
     name: 'appcs-${solutionSuffix}'
-    location: solutionLocation
+    location: location
     managedIdentities: { systemAssigned: true }
     sku: 'Standard'
     enableTelemetry: enableTelemetry
@@ -1115,7 +1111,7 @@ module containerAppBackend 'br/public:avm/res/app/container-app:0.18.1' = {
   dependsOn: [applicationInsights]
   params: {
     name: backendContainerAppName
-    location: solutionLocation
+    location: location
     environmentResourceId: containerAppsEnvironment.outputs.resourceId
     tags: union(allTags, { 'azd-service-name': 'backend' })
     managedIdentities: {
@@ -1208,7 +1204,7 @@ module containerAppFrontend 'br/public:avm/res/app/container-app:0.18.1' = {
   name: take('avm.res.app.container-app.${frontEndContainerAppName}', 64)
   params: {
     name: frontEndContainerAppName
-    location: solutionLocation
+    location: location
     environmentResourceId: containerAppsEnvironment.outputs.resourceId
     tags: union(allTags, { 'azd-service-name': 'frontend' })
     managedIdentities: {
@@ -1274,7 +1270,7 @@ module containerAppProcessor 'br/public:avm/res/app/container-app:0.18.1' = {
   dependsOn: [applicationInsights]
   params: {
     name: processorContainerAppName
-    location: solutionLocation
+    location: location
     environmentResourceId: containerAppsEnvironment.outputs.resourceId
     tags: union(allTags, { 'azd-service-name': 'processor' })
     managedIdentities: {


### PR DESCRIPTION
Updated location parameter references and descriptions for various resources.

## Purpose

This pull request simplifies and unifies the handling of Azure region parameters in the `infra/main.bicep` file. The key change is the consistent use of the `location` parameter for resource deployment, replacing previous usage of `solutionLocation` and `cosmosLocation` variables. Additionally, the Cosmos DB and AI deployment location parameters have been cleaned up for clarity.

**Parameter and variable simplification:**

* Updated the `location` parameter description to include Cosmos DB and removed the unnecessary `solutionLocation` variable, ensuring all resources use the same region parameter.
* Removed the redundant `cosmosLocation` parameter and ensured Cosmos DB resources use the main `location` parameter. [[1]](diffhunk://#diff-7ef659fc9cf6968e718894d300490b14ea7a52091e7d4bcffae3a5029ac721d4L114-L116) [[2]](diffhunk://#diff-7ef659fc9cf6968e718894d300490b14ea7a52091e7d4bcffae3a5029ac721d4L613-R592)

**Resource module updates:**

* Updated all resource module definitions (e.g., managed identities, log analytics, storage, Cosmos DB, App Configuration, Container Apps) to use the unified `location` parameter instead of `solutionLocation` or `cosmosLocation`. [[1]](diffhunk://#diff-7ef659fc9cf6968e718894d300490b14ea7a52091e7d4bcffae3a5029ac721d4L232-R211) [[2]](diffhunk://#diff-7ef659fc9cf6968e718894d300490b14ea7a52091e7d4bcffae3a5029ac721d4L246-R225) [[3]](diffhunk://#diff-7ef659fc9cf6968e718894d300490b14ea7a52091e7d4bcffae3a5029ac721d4L311-R290) [[4]](diffhunk://#diff-7ef659fc9cf6968e718894d300490b14ea7a52091e7d4bcffae3a5029ac721d4L495-R474) [[5]](diffhunk://#diff-7ef659fc9cf6968e718894d300490b14ea7a52091e7d4bcffae3a5029ac721d4L613-R592) [[6]](diffhunk://#diff-7ef659fc9cf6968e718894d300490b14ea7a52091e7d4bcffae3a5029ac721d4L695-R674) [[7]](diffhunk://#diff-7ef659fc9cf6968e718894d300490b14ea7a52091e7d4bcffae3a5029ac721d4L705-R684) [[8]](diffhunk://#diff-7ef659fc9cf6968e718894d300490b14ea7a52091e7d4bcffae3a5029ac721d4L921-R900) [[9]](diffhunk://#diff-7ef659fc9cf6968e718894d300490b14ea7a52091e7d4bcffae3a5029ac721d4L971-R950) [[10]](diffhunk://#diff-7ef659fc9cf6968e718894d300490b14ea7a52091e7d4bcffae3a5029ac721d4L1099-R1078) [[11]](diffhunk://#diff-7ef659fc9cf6968e718894d300490b14ea7a52091e7d4bcffae3a5029ac721d4L1180-R1159) [[12]](diffhunk://#diff-7ef659fc9cf6968e718894d300490b14ea7a52091e7d4bcffae3a5029ac721d4L1267-R1246) [[13]](diffhunk://#diff-7ef659fc9cf6968e718894d300490b14ea7a52091e7d4bcffae3a5029ac721d4L1335-R1314)

**Parameter cleanup:**

* Removed the unused `aiDeploymentLocation` parameter and its allowed values, consolidating AI service location handling.

These changes make the infrastructure code more maintainable and reduce the risk of region mismatches between resources.

## Does this introduce a breaking change?
<!-- Mark one with an "x". -->

- [ ] Yes
- [x] No

<!-- Please prefix your PR title with one of the following:
  * `feat`: A new feature
  * `fix`: A bug fix
  * `docs`: Documentation only changes
  * `style`: Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc)
  * `refactor`: A code change that neither fixes a bug nor adds a feature
  * `perf`: A code change that improves performance
  * `test`: Adding missing tests or correcting existing tests
  * `build`: Changes that affect the build system or external dependencies (example scopes: gulp, broccoli, npm)
  * `ci`: Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
  * `chore`: Other changes that don't modify src or test files
  * `revert`: Reverts a previous commit
  * !: A breaking change is indicated with a `!` after the listed prefixes above, e.g. `feat!`, `fix!`, `refactor!`, etc.
-->

## Golden Path Validation
- [x] I have tested the primary workflows (the "golden path") to ensure they function correctly without errors.

## Deployment Validation
- [x] I have validated the deployment process successfully and all services are running as expected with this change.

## What to Check
Verify that the following are valid
* ...

## Other Information

<!-- Add any other helpful information that may be needed here. -->
