### PR TITLE
chore: Add tags to prevent SFI W18 Policy violation

### DIFF
--- a/infra/main.bicep
+++ b/infra/main.bicep
@@ -1125,11 +1125,9 @@ module containerAppsEnvironment 'br/public:avm/res/app/managed-environment:0.11.
     location: location
     tags: {
       ...resourceGroup().tags
+      ...existingTags
+      ...allTags
       ...tags
-      TemplateName: 'Content Processing'
-      Type: enablePrivateNetworking ? 'WAF' : 'Non-WAF'
-      CreatedBy: createdBy
-      DeploymentName: deployment().name
     }
     managedIdentities: { systemAssigned: true }
     appLogsConfiguration: enableMonitoring

--- a/infra/main.bicep
+++ b/infra/main.bicep
@@ -1126,6 +1126,10 @@ module containerAppsEnvironment 'br/public:avm/res/app/managed-environment:0.11.
     tags: {
       ...resourceGroup().tags
       ...tags
+      TemplateName: 'Content Processing'
+      Type: enablePrivateNetworking ? 'WAF' : 'Non-WAF'
+      CreatedBy: createdBy
+      DeploymentName: deployment().name
     }
     managedIdentities: { systemAssigned: true }
     appLogsConfiguration: enableMonitoring

--- a/infra/main.bicep
+++ b/infra/main.bicep
@@ -1123,6 +1123,10 @@ module containerAppsEnvironment 'br/public:avm/res/app/managed-environment:0.11.
   params: {
     name: 'cae-${solutionSuffix}'
     location: location
+    tags: {
+      ...resourceGroup().tags
+      ...tags
+    }
     managedIdentities: { systemAssigned: true }
     appLogsConfiguration: enableMonitoring
       ? {

--- a/infra/main.json
+++ b/infra/main.json
@@ -6,7 +6,7 @@
     "_generator": {
       "name": "bicep",
       "version": "0.43.8.12551",
-      "templateHash": "11275932789751936226"
+      "templateHash": "7630070384569998511"
     }
   },
   "parameters": {
@@ -38363,7 +38363,7 @@
             "value": "[parameters('location')]"
           },
           "tags": {
-            "value": "[shallowMerge(createArray(resourceGroup().tags, parameters('tags'), createObject('TemplateName', 'Content Processing', 'Type', if(parameters('enablePrivateNetworking'), 'WAF', 'Non-WAF'), 'CreatedBy', parameters('createdBy'), 'DeploymentName', deployment().name)))]"
+            "value": "[shallowMerge(createArray(resourceGroup().tags, variables('existingTags'), variables('allTags'), parameters('tags')))]"
           },
           "managedIdentities": {
             "value": {

--- a/infra/main.json
+++ b/infra/main.json
@@ -5,8 +5,8 @@
   "metadata": {
     "_generator": {
       "name": "bicep",
-      "version": "0.39.26.7824",
-      "templateHash": "10416093194621236912"
+      "version": "0.43.8.12551",
+      "templateHash": "11275932789751936226"
     }
   },
   "parameters": {
@@ -4715,8 +4715,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.39.26.7824",
-              "templateHash": "9098270296053650342"
+              "version": "0.43.8.12551",
+              "templateHash": "4604761290796021104"
             }
           },
           "definitions": {
@@ -30103,8 +30103,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.39.26.7824",
-              "templateHash": "7473169155225322335"
+              "version": "0.43.8.12551",
+              "templateHash": "13516349791985095953"
             }
           },
           "definitions": {
@@ -30411,7 +30411,7 @@
               },
               "type": "Microsoft.Authorization/roleAssignments",
               "apiVersion": "2022-04-01",
-              "scope": "[format('Microsoft.CognitiveServices/accounts/{0}', parameters('name'))]",
+              "scope": "[resourceId('Microsoft.CognitiveServices/accounts', parameters('name'))]",
               "name": "[coalesce(tryGet(coalesce(variables('formattedRoleAssignments'), createArray())[copyIndex()], 'name'), guid(resourceId('Microsoft.CognitiveServices/accounts', parameters('name')), coalesce(variables('formattedRoleAssignments'), createArray())[copyIndex()].principalId, coalesce(variables('formattedRoleAssignments'), createArray())[copyIndex()].roleDefinitionId))]",
               "properties": {
                 "roleDefinitionId": "[coalesce(variables('formattedRoleAssignments'), createArray())[copyIndex()].roleDefinitionId]",
@@ -33854,8 +33854,8 @@
       "dependsOn": [
         "aiFoundryAiServices",
         "[format('avmPrivateDnsZones[{0}]', variables('dnsZoneIndex').aiServices)]",
-        "[format('avmPrivateDnsZones[{0}]', variables('dnsZoneIndex').cognitiveServices)]",
         "[format('avmPrivateDnsZones[{0}]', variables('dnsZoneIndex').openAI)]",
+        "[format('avmPrivateDnsZones[{0}]', variables('dnsZoneIndex').cognitiveServices)]",
         "virtualNetwork"
       ]
     },
@@ -33892,8 +33892,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.39.26.7824",
-              "templateHash": "13634050148372048883"
+              "version": "0.43.8.12551",
+              "templateHash": "17583277036649944863"
             }
           },
           "parameters": {
@@ -38363,7 +38363,7 @@
             "value": "[parameters('location')]"
           },
           "tags": {
-            "value": "[shallowMerge(createArray(resourceGroup().tags, parameters('tags')))]"
+            "value": "[shallowMerge(createArray(resourceGroup().tags, parameters('tags'), createObject('TemplateName', 'Content Processing', 'Type', if(parameters('enablePrivateNetworking'), 'WAF', 'Non-WAF'), 'CreatedBy', parameters('createdBy'), 'DeploymentName', deployment().name)))]"
           },
           "managedIdentities": {
             "value": {

--- a/infra/main.json
+++ b/infra/main.json
@@ -5,8 +5,8 @@
   "metadata": {
     "_generator": {
       "name": "bicep",
-      "version": "0.43.1.21952",
-      "templateHash": "1278209883407272359"
+      "version": "0.39.26.7824",
+      "templateHash": "10416093194621236912"
     }
   },
   "parameters": {
@@ -4715,8 +4715,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.43.1.21952",
-              "templateHash": "4488065934246762087"
+              "version": "0.39.26.7824",
+              "templateHash": "9098270296053650342"
             }
           },
           "definitions": {
@@ -26135,8 +26135,8 @@
       },
       "dependsOn": [
         "appIdentity",
-        "[format('avmPrivateDnsZones[{0}]', variables('dnsZoneIndex').storageQueue)]",
         "[format('avmPrivateDnsZones[{0}]', variables('dnsZoneIndex').storageBlob)]",
+        "[format('avmPrivateDnsZones[{0}]', variables('dnsZoneIndex').storageQueue)]",
         "virtualNetwork"
       ]
     },
@@ -30103,8 +30103,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.43.1.21952",
-              "templateHash": "17526785557845507677"
+              "version": "0.39.26.7824",
+              "templateHash": "7473169155225322335"
             }
           },
           "definitions": {
@@ -30411,7 +30411,7 @@
               },
               "type": "Microsoft.Authorization/roleAssignments",
               "apiVersion": "2022-04-01",
-              "scope": "[resourceId('Microsoft.CognitiveServices/accounts', parameters('name'))]",
+              "scope": "[format('Microsoft.CognitiveServices/accounts/{0}', parameters('name'))]",
               "name": "[coalesce(tryGet(coalesce(variables('formattedRoleAssignments'), createArray())[copyIndex()], 'name'), guid(resourceId('Microsoft.CognitiveServices/accounts', parameters('name')), coalesce(variables('formattedRoleAssignments'), createArray())[copyIndex()].principalId, coalesce(variables('formattedRoleAssignments'), createArray())[copyIndex()].roleDefinitionId))]",
               "properties": {
                 "roleDefinitionId": "[coalesce(variables('formattedRoleAssignments'), createArray())[copyIndex()].roleDefinitionId]",
@@ -33853,9 +33853,9 @@
       },
       "dependsOn": [
         "aiFoundryAiServices",
-        "[format('avmPrivateDnsZones[{0}]', variables('dnsZoneIndex').openAI)]",
-        "[format('avmPrivateDnsZones[{0}]', variables('dnsZoneIndex').cognitiveServices)]",
         "[format('avmPrivateDnsZones[{0}]', variables('dnsZoneIndex').aiServices)]",
+        "[format('avmPrivateDnsZones[{0}]', variables('dnsZoneIndex').cognitiveServices)]",
+        "[format('avmPrivateDnsZones[{0}]', variables('dnsZoneIndex').openAI)]",
         "virtualNetwork"
       ]
     },
@@ -33892,8 +33892,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.43.1.21952",
-              "templateHash": "8251376928798842081"
+              "version": "0.39.26.7824",
+              "templateHash": "13634050148372048883"
             }
           },
           "parameters": {
@@ -38361,6 +38361,9 @@
           },
           "location": {
             "value": "[parameters('location')]"
+          },
+          "tags": {
+            "value": "[shallowMerge(createArray(resourceGroup().tags, parameters('tags')))]"
           },
           "managedIdentities": {
             "value": {

--- a/infra/main.parameters.json
+++ b/infra/main.parameters.json
@@ -40,6 +40,9 @@
       },
       "imageTag": {
         "value": "${AZURE_ENV_IMAGE_TAG}"
+      },
+      "tags": {
+       "value": "${AZURE_ENV_TAGS}"
       }
     }
 }

--- a/infra/main.waf.parameters.json
+++ b/infra/main.waf.parameters.json
@@ -55,6 +55,9 @@
       },
       "vmSize": {
         "value": "${AZURE_ENV_VM_SIZE}"
+      },
+      "tags": {
+       "value": "${AZURE_ENV_TAGS}"
       }
     }
 }

--- a/infra/main_custom.bicep
+++ b/infra/main_custom.bicep
@@ -1079,6 +1079,10 @@ module containerAppsEnvironment 'br/public:avm/res/app/managed-environment:0.11.
     tags: {
       ...resourceGroup().tags
       ...tags
+      TemplateName: 'Content Processing'
+      Type: enablePrivateNetworking ? 'WAF' : 'Non-WAF'
+      CreatedBy: createdBy
+      DeploymentName: deployment().name
     }
     managedIdentities: { systemAssigned: true }
     appLogsConfiguration: enableMonitoring

--- a/infra/main_custom.bicep
+++ b/infra/main_custom.bicep
@@ -1076,6 +1076,10 @@ module containerAppsEnvironment 'br/public:avm/res/app/managed-environment:0.11.
   params: {
     name: 'cae-${solutionSuffix}'
     location: location
+    tags: {
+      ...resourceGroup().tags
+      ...tags
+    }
     managedIdentities: { systemAssigned: true }
     appLogsConfiguration: enableMonitoring
       ? {

--- a/infra/main_custom.bicep
+++ b/infra/main_custom.bicep
@@ -1078,11 +1078,9 @@ module containerAppsEnvironment 'br/public:avm/res/app/managed-environment:0.11.
     location: location
     tags: {
       ...resourceGroup().tags
+      ...existingTags
+      ...allTags
       ...tags
-      TemplateName: 'Content Processing'
-      Type: enablePrivateNetworking ? 'WAF' : 'Non-WAF'
-      CreatedBy: createdBy
-      DeploymentName: deployment().name
     }
     managedIdentities: { systemAssigned: true }
     appLogsConfiguration: enableMonitoring


### PR DESCRIPTION
## Purpose
This pull request updates the infrastructure code to improve tag management for resources and makes some minor corrections and optimizations in the generated ARM templates. The most significant change is the addition of logic to merge resource group tags with custom tags for the container apps environment, ensuring consistent tagging. There are also minor updates to resource dependencies and template formatting.

Tag management improvements:

* Updated both `infra/main.bicep` and `infra/main_custom.bicep` to merge `resourceGroup().tags` with custom `tags` when setting the `tags` parameter for the `containerAppsEnvironment` module, ensuring all resources inherit both sets of tags. [[1]](diffhunk://#diff-7ef659fc9cf6968e718894d300490b14ea7a52091e7d4bcffae3a5029ac721d4R1126-R1129) [[2]](diffhunk://#diff-6f5772bf1f1d80cc16f30c80915d9e5622ad0637daf5b5dff29308ad5fc68b62R1079-R1082)
* Updated the corresponding ARM template (`infra/main.json`) to use a `shallowMerge` of `resourceGroup().tags` and `parameters('tags')` for the `tags` property of the container apps environment resource.

Template and dependency corrections:

* Fixed the order of dependencies in `infra/main.json` for private DNS zones to ensure correct deployment sequencing. [[1]](diffhunk://#diff-0504f5a35afecd5c8c2a1dc8cac5bb558cc1456c557d8edcb7f9bac1c0dc36e4L26138-R26139) [[2]](diffhunk://#diff-0504f5a35afecd5c8c2a1dc8cac5bb558cc1456c557d8edcb7f9bac1c0dc36e4L33856-R33858)
* Corrected the `scope` property in the role assignment resource to use `format()` instead of `resourceId()` for constructing the resource scope string.

Template metadata updates:

* Updated `_generator` metadata and `templateHash` values in several places in `infra/main.json` to reflect changes in the Bicep compiler version and template content. [[1]](diffhunk://#diff-0504f5a35afecd5c8c2a1dc8cac5bb558cc1456c557d8edcb7f9bac1c0dc36e4L8-R9) [[2]](diffhunk://#diff-0504f5a35afecd5c8c2a1dc8cac5bb558cc1456c557d8edcb7f9bac1c0dc36e4L4718-R4719) [[3]](diffhunk://#diff-0504f5a35afecd5c8c2a1dc8cac5bb558cc1456c557d8edcb7f9bac1c0dc36e4L30106-R30107) [[4]](diffhunk://#diff-0504f5a35afecd5c8c2a1dc8cac5bb558cc1456c557d8edcb7f9bac1c0dc36e4L33895-R33896)

## Does this introduce a breaking change?
<!-- Mark one with an "x". -->

- [ ] Yes
- [X] No

<!-- Please prefix your PR title with one of the following:
  * `feat`: A new feature
  * `fix`: A bug fix
  * `docs`: Documentation only changes
  * `style`: Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc)
  * `refactor`: A code change that neither fixes a bug nor adds a feature
  * `perf`: A code change that improves performance
  * `test`: Adding missing tests or correcting existing tests
  * `build`: Changes that affect the build system or external dependencies (example scopes: gulp, broccoli, npm)
  * `ci`: Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
  * `chore`: Other changes that don't modify src or test files
  * `revert`: Reverts a previous commit
  * !: A breaking change is indicated with a `!` after the listed prefixes above, e.g. `feat!`, `fix!`, `refactor!`, etc.
-->

## Golden Path Validation
- [ ] I have tested the primary workflows (the "golden path") to ensure they function correctly without errors.

## Deployment Validation
- [ ] I have validated the deployment process successfully and all services are running as expected with this change.

## What to Check
Verify that the following are valid
* ...

## Other Information

<!-- Add any other helpful information that may be needed here. -->
