### PR TITLE
test: resolve PR #242 review comments (CodeQL + Copilot)

### DIFF
--- a/src/backend-api/src/tests/sas/storage/blob/test_async_helper_extra.py
+++ b/src/backend-api/src/tests/sas/storage/blob/test_async_helper_extra.py
@@ -81,13 +81,16 @@ def _wire_credential(svc_cls, *, account_key=None, account_name="myacct",
                      credential_cls_name="DefaultAzureCredential"):
     svc = _wire(svc_cls)
     svc.account_name = account_name
+    # Use a dedicated stub class per credential type so that ``type(cred).__name__``
+    # reflects the desired credential class without mutating the shared ``MagicMock``
+    # class metadata (which would leak across tests and make order-dependent failures).
     if credential_cls_name == "AccountKey":
-        cred = MagicMock()
+        cred_cls = type("StorageSharedKeyCredential", (), {})
+        cred = cred_cls()
         cred.account_key = account_key
-        type(cred).__name__ = "StorageSharedKeyCredential"
     else:
-        cred = MagicMock(spec=[])
-        type(cred).__name__ = credential_cls_name
+        cred_cls = type(credential_cls_name, (), {})
+        cred = cred_cls()
     svc.credential = cred
     return svc
 

--- a/src/backend-api/src/tests/sas/storage/blob/test_config.py
+++ b/src/backend-api/src/tests/sas/storage/blob/test_config.py
@@ -1,12 +1,9 @@
 """Tests for libs/sas/storage/blob/config.py."""
 
-import pytest
-
 from libs.sas.storage.blob import config as blob_config_module
 from libs.sas.storage.blob.config import (
     BlobHelperConfig,
     create_config,
-    default_config,
     get_config,
     set_config,
 )

--- a/src/backend-api/src/tests/sas/storage/blob/test_helper_extra.py
+++ b/src/backend-api/src/tests/sas/storage/blob/test_helper_extra.py
@@ -66,16 +66,21 @@ class TestDeleteContainerForceErrorBranches:
 
 def _wire_credential(blob_service_mock, *, account_key=None, account_name="myacct",
                      credential_cls_name="DefaultAzureCredential"):
-    """Make the helper's blob_service_client respond like an Azure SDK client."""
+    """Make the helper's blob_service_client respond like an Azure SDK client.
+
+    Uses a dedicated stub class per credential type so that ``type(cred).__name__``
+    reflects the desired credential class without mutating the shared ``MagicMock``
+    class metadata (which would leak across tests).
+    """
     h = _make_helper(blob_service_mock)
     h.blob_service_client.account_name = account_name
     if credential_cls_name == "AccountKey":
-        cred = MagicMock()
+        cred_cls = type("StorageSharedKeyCredential", (), {})
+        cred = cred_cls()
         cred.account_key = account_key
-        type(cred).__name__ = "StorageSharedKeyCredential"
     else:
-        cred = MagicMock(spec=[])
-        type(cred).__name__ = credential_cls_name
+        cred_cls = type(credential_cls_name, (), {})
+        cred = cred_cls()
     h.blob_service_client.credential = cred
     return h
 

--- a/src/processor/src/tests/unit/libs/agent_framework/test_agent_speaking_capture.py
+++ b/src/processor/src/tests/unit/libs/agent_framework/test_agent_speaking_capture.py
@@ -2,9 +2,8 @@
 # Licensed under the MIT License.
 
 import asyncio
-from datetime import datetime
 from types import SimpleNamespace
-from unittest.mock import AsyncMock, MagicMock
+from unittest.mock import AsyncMock
 
 from libs.agent_framework.agent_speaking_capture import AgentSpeakingCaptureMiddleware
 

--- a/src/processor/src/tests/unit/libs/base/test_application_base_init.py
+++ b/src/processor/src/tests/unit/libs/base/test_application_base_init.py
@@ -5,7 +5,6 @@
 
 from __future__ import annotations
 
-import inspect
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -71,7 +70,7 @@ class TestApplicationBaseInit:
         env_file = tmp_path / ".env"
         env_file.write_text("X=1")
         _App = _build_concrete()
-        app = _App(env_file_path=str(env_file))
+        _App(env_file_path=str(env_file))
         patches_chain["ac_helper"].assert_called_once()
         # The helper instance had its method invoked
         helper_instance = patches_chain["ac_helper"].return_value

--- a/src/processor/src/tests/unit/services/test_queue_service_internals.py
+++ b/src/processor/src/tests/unit/services/test_queue_service_internals.py
@@ -714,7 +714,6 @@ class TestCleanupBlobsSync:
 
     def test_output_cleanup_refuses_broad_prefix(self):
         s = _service()
-        tp = _task_param()
         # Force output_file_folder to broad path matching "<pid>"
         tp = Analysis_TaskParam(
             process_id="p1",
@@ -783,9 +782,6 @@ class TestStartService:
         s.is_running = False
         s._ensure_queues_exist = AsyncMock()
         s._control_watcher_loop = AsyncMock()
-
-        async def _no_op_worker(self_, worker_id):
-            return None
 
         # Patch worker loop to immediate return
         s._worker_loop = lambda wid: asyncio.sleep(0)  # type: ignore[assignment]

--- a/src/processor/src/tests/unit/utils/test_agent_telemetry.py
+++ b/src/processor/src/tests/unit/utils/test_agent_telemetry.py
@@ -2,7 +2,6 @@
 # Licensed under the MIT License.
 
 import asyncio
-from datetime import UTC, datetime
 from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock, patch
 

--- a/src/processor/src/tests/unit/utils/test_agent_telemetry_records.py
+++ b/src/processor/src/tests/unit/utils/test_agent_telemetry_records.py
@@ -8,8 +8,6 @@ from __future__ import annotations
 import asyncio
 from unittest.mock import AsyncMock, MagicMock, patch
 
-import pytest
-
 import utils.agent_telemetry as at
 from utils.agent_telemetry import ProcessStatus, TelemetryManager
 


### PR DESCRIPTION
## Purpose

Resolves all review comments on #242 (the open `dev -> main` PR).

### CodeQL (`github-code-quality`) — unused imports / variables

- `src/processor/src/tests/unit/services/test_queue_service_internals.py`
  - Drop redundant `tp = _task_param()` in `test_output_cleanup_refuses_broad_prefix`.
  - Drop unused `_no_op_worker` in `test_start_service_runs_and_completes`.
- `src/processor/src/tests/unit/libs/base/test_application_base_init.py`
  - Drop unused `import inspect`.
  - Drop unused `app` local in `test_init_loads_app_config_when_url_set`.
- `src/processor/src/tests/unit/libs/agent_framework/test_agent_speaking_capture.py`
  - Drop unused `datetime` / `MagicMock` imports.
- `src/processor/src/tests/unit/utils/test_agent_telemetry.py`
  - Drop unused `from datetime import UTC, datetime` (only the literal ` UTC` string is used).
- `src/processor/src/tests/unit/utils/test_agent_telemetry_records.py`
  - Drop unused `import pytest`.
- `src/backend-api/src/tests/sas/storage/blob/test_config.py`
  - Drop unused `pytest` import and unused `default_config` symbol (still referenced via `blob_config_module.default_config`).

### Copilot review — order-dependent MagicMock leak

- `src/backend-api/src/tests/sas/storage/blob/test_async_helper_extra.py`
- `src/backend-api/src/tests/sas/storage/blob/test_helper_extra.py`

In `_wire_credential`, the tests were mutating `type(cred).__name__` on a `MagicMock()`. Because every `MagicMock()` instance shares the same `MagicMock` class, that assignment globally renames `MagicMock` — so any later test that introspects `type(...).__name__` sees whatever the last test set, producing order-dependent / flaky behavior.

Replaced the mutation with a dedicated dynamically-created stub class per credential type (e.g. `type('DefaultAzureCredential', (), {})`). This:

- Scopes `__name__` to a fresh class per call (no leakage).
- Preserves `hasattr(cred, 'account_key')` semantics for both the account-key path (attribute set on the stub) and the AAD path (attribute absent).
- Keeps all existing call sites unchanged.

## Verification

- `cd src/backend-api && PYTHONPATH=src/app pytest src/tests -c NUL --rootdir=. --cov=src/app --cov-fail-under=82`
  - 585 passing, `93.28%` coverage. (1 unrelated env failure when locally authenticated against the placeholder `example.azconfig.io`; passes in CI where no Azure credentials are present.)
- `cd src/processor && pytest src/tests --cov=src --cov-fail-under=82`
  - 812 passing, `87.44%` coverage.

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

## Golden Path Validation

- [x] Test-only change; backend + processor unit suites continue to pass and meet the 82% coverage gate.

## Deployment Validation

- [x] No runtime / deployment code touched.