### PR TITLE
fix(processor): retry 'model produced invalid content' and bump Resul…

### DIFF
--- a/src/processor/src/libs/agent_framework/azure_openai_response_retry.py
+++ b/src/processor/src/libs/agent_framework/azure_openai_response_retry.py
@@ -78,6 +78,14 @@ def _looks_like_rate_limit(error: BaseException) -> bool:
     if isinstance(status, int) and 500 <= status < 600:
         return True
 
+    # "The model produced invalid content" is a transient error from Azure OpenAI
+    # when the model output fails content/schema validation — worth retrying.
+    if any(
+        s in msg
+        for s in ["model produced invalid content", "invalid content"]
+    ):
+        return True
+
     cause = getattr(error, "__cause__", None)
     if cause and cause is not error:
         return _looks_like_rate_limit(cause)

--- a/src/processor/src/libs/base/orchestrator_base.py
+++ b/src/processor/src/libs/base/orchestrator_base.py
@@ -188,10 +188,12 @@ class OrchestratorBase(AgentBase, Generic[TaskParamT, ResultT]):
                 )
             elif agent_info.agent_name == "ResultGenerator":
                 # Structured JSON generation; deterministic and bounded.
+                # Use 25_000 to prevent truncation of complex nested JSON schemas
+                # which causes "model produced invalid content" errors.
                 builder = (
                     builder
                     .with_temperature(0.0)
-                    .with_max_tokens(12_000)
+                    .with_max_tokens(25_000)
                     .with_tool_choice("none")
                 )
 


### PR DESCRIPTION
## Purpose
<!-- Describe the intention of the changes being proposed. What problem does it solve or functionality does it add? -->
This pull request addresses transient errors from Azure OpenAI related to invalid content generation and improves the reliability of structured JSON generation in the `ResultGenerator` agent. The main changes are:

**Error Handling Improvements:**

* Updated the `_looks_like_rate_limit` function in `azure_openai_response_retry.py` to treat "model produced invalid content" and similar messages as transient errors, making them eligible for retry.

**Agent Configuration Adjustments:**

* Increased the `max_tokens` limit for the `ResultGenerator` agent from 12,000 to 25,000 in `orchestrator_base.py` to prevent truncation of complex nested JSON schemas, which previously caused "model produced invalid content" errors.

## Does this introduce a breaking change?
<!-- Mark one with an "x". -->

- [ ] Yes
- [x] No

<!-- Please prefix your PR title with one of the following:
  * `feat`: A new feature
  * `fix`: A bug fix
  * `docs`: Documentation only changes
  * `style`: Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc)
  * `refactor`: A code change that neither fixes a bug nor adds a feature
  * `perf`: A code change that improves performance
  * `test`: Adding missing tests or correcting existing tests
  * `build`: Changes that affect the build system or external dependencies (example scopes: gulp, broccoli, npm)
  * `ci`: Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
  * `chore`: Other changes that don't modify src or test files
  * `revert`: Reverts a previous commit
  * !: A breaking change is indicated with a `!` after the listed prefixes above, e.g. `feat!`, `fix!`, `refactor!`, etc.
-->

## Golden Path Validation
- [x] I have tested the primary workflows (the "golden path") to ensure they function correctly without errors.

## Deployment Validation
- [x] I have validated the deployment process successfully and all services are running as expected with this change.

## What to Check
Verify that the following are valid
* ...

## Other Information

<!-- Add any other helpful information that may be needed here. -->
