### PR TITLE
chore: sync main hotfix (v2.0.4) into dev

### DIFF
--- a/src/processor/src/libs/agent_framework/azure_openai_response_retry.py
+++ b/src/processor/src/libs/agent_framework/azure_openai_response_retry.py
@@ -78,6 +78,14 @@ def _looks_like_rate_limit(error: BaseException) -> bool:
     if isinstance(status, int) and 500 <= status < 600:
         return True
 
+    # "The model produced invalid content" is a transient error from Azure OpenAI
+    # when the model output fails content/schema validation — worth retrying.
+    if any(
+        s in msg
+        for s in ["model produced invalid content", "invalid content"]
+    ):
+        return True
+
     cause = getattr(error, "__cause__", None)
     if cause and cause is not error:
         return _looks_like_rate_limit(cause)

--- a/src/processor/src/libs/base/orchestrator_base.py
+++ b/src/processor/src/libs/base/orchestrator_base.py
@@ -188,10 +188,12 @@ class OrchestratorBase(AgentBase, Generic[TaskParamT, ResultT]):
                 )
             elif agent_info.agent_name == "ResultGenerator":
                 # Structured JSON generation; deterministic and bounded.
+                # Use 25_000 to prevent truncation of complex nested JSON schemas
+                # which causes "model produced invalid content" errors.
                 builder = (
                     builder
                     .with_temperature(0.0)
-                    .with_max_tokens(12_000)
+                    .with_max_tokens(25_000)
                     .with_tool_choice("none")
                 )
 


### PR DESCRIPTION
## Purpose
<!-- Describe the intention of the changes being proposed. What problem does it solve or functionality does it add? -->
* Forward-port the changes that shipped in `main` tag `v2.0.4` (`5a0efca`) into `dev` so the two trunks stay in sync.
* Carries the Bug #43771 processor fix (retry on `model produced invalid content` and `ResultGenerator.max_tokens` bump) into `dev`.
* `dev` is otherwise 34 commits ahead of `main` on unrelated work; this PR only forward-ports the two commits below.

## Does this introduce a breaking change?
<!-- Mark one with an "x". -->

- [ ] Yes
- [x] No

## Golden Path Validation
- [x] I have tested the primary workflows (the "golden path") to ensure they function correctly without errors.
<!-- Both commits were already validated on `main` via PR #248 prior to the `v2.0.4` tag. -->

## Deployment Validation
- [x] I have validated the deployment process successfully and all services are running as expected with this change.
<!-- Deployment of `v2.0.4` from `main` is the validation evidence; no additional infra/app changes are introduced by this sync PR. -->

## What to Check
Verify that the following are valid
* Only two commits are introduced into `dev`:
  * `5a0efca` Merge pull request #248 from microsoft/psl-sw/43771-design-fix-from-main
  * `3dfa183` fix(processor): retry 'model produced invalid content' and bump `ResultGenerator` max_tokens (Bug #43771)
* No merge conflicts and no unintended file changes outside `src/processor` for the Bug #43771 fix.
* Branch `chore/sync-main-into-dev-2026-05-20` was created off `origin/main` @ `5a0efca` (tag `v2.0.4`) with no additional commits on top.

## Other Information

<!-- Add any other helpful information that may be needed here. -->
* Upstream PR: microsoft/Container-Migration-Solution-Accelerator#248
* Released tag on `main`: `v2.0.4`
* This is a periodic `main` -> `dev` sync; please use a **merge commit** (not squash) to preserve the original SHAs from `main`.