### PR TITLE
fix: update werkzeug to 3.1.6 and add idna 3.15 to dependencies

### DIFF
--- a/src/backend-api/pyproject.toml
+++ b/src/backend-api/pyproject.toml
@@ -38,10 +38,11 @@ override-dependencies = [
     "azure-core==1.38.0",
     "urllib3==2.7.0",
     "requests==2.33.0",
-    "werkzeug==3.1.4",
+    "werkzeug==3.1.6",
     "pygments==2.20.0",
     "black==26.3.1",
     "cryptography==46.0.7",
     "pyjwt==2.12.0",
     "pyopenssl==26.0.0",
+    "idna==3.15",
 ]

--- a/src/backend-api/uv.lock
+++ b/src/backend-api/uv.lock
@@ -14,13 +14,14 @@ overrides = [
     { name = "azure-core", specifier = "==1.38.0" },
     { name = "black", specifier = "==26.3.1" },
     { name = "cryptography", specifier = "==46.0.7" },
+    { name = "idna", specifier = "==3.15" },
     { name = "pygments", specifier = "==2.20.0" },
     { name = "pyjwt", specifier = "==2.12.0" },
     { name = "pyopenssl", specifier = "==26.0.0" },
     { name = "requests", specifier = "==2.33.0" },
     { name = "starlette", specifier = "==0.49.1" },
     { name = "urllib3", specifier = "==2.7.0" },
-    { name = "werkzeug", specifier = "==3.1.4" },
+    { name = "werkzeug", specifier = "==3.1.6" },
 ]
 
 [[package]]
@@ -1276,11 +1277,11 @@ wheels = [
 
 [[package]]
 name = "idna"
-version = "3.13"
+version = "3.15"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/ce/cc/762dfb036166873f0059f3b7de4565e1b5bc3d6f28a414c13da27e442f99/idna-3.13.tar.gz", hash = "sha256:585ea8fe5d69b9181ec1afba340451fba6ba764af97026f92a91d4eef164a242", size = 194210, upload-time = "2026-04-22T16:42:42.314Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/82/77/7b3966d0b9d1d31a36ddf1746926a11dface89a83409bf1483f0237aa758/idna-3.15.tar.gz", hash = "sha256:ca962446ea538f7092a95e057da437618e886f4d349216d2b1e294abfdb65fdc", size = 199245, upload-time = "2026-05-12T22:45:57.011Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/5d/13/ad7d7ca3808a898b4612b6fe93cde56b53f3034dcde235acb1f0e1df24c6/idna-3.13-py3-none-any.whl", hash = "sha256:892ea0cde124a99ce773decba204c5552b69c3c67ffd5f232eb7696135bc8bb3", size = 68629, upload-time = "2026-04-22T16:42:40.909Z" },
+    { url = "https://files.pythonhosted.org/packages/d2/23/408243171aa9aaba178d3e2559159c24c1171a641aa83b67bdd3394ead8e/idna-3.15-py3-none-any.whl", hash = "sha256:048adeaf8c2d788c40fee287673ccaa74c24ffd8dcf09ffa555a2fbb59f10ac8", size = 72340, upload-time = "2026-05-12T22:45:55.733Z" },
 ]
 
 [[package]]
@@ -3301,14 +3302,14 @@ wheels = [
 
 [[package]]
 name = "werkzeug"
-version = "3.1.4"
+version = "3.1.6"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "markupsafe" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/45/ea/b0f8eeb287f8df9066e56e831c7824ac6bab645dd6c7a8f4b2d767944f9b/werkzeug-3.1.4.tar.gz", hash = "sha256:cd3cd98b1b92dc3b7b3995038826c68097dcb16f9baa63abe35f20eafeb9fe5e", size = 864687, upload-time = "2025-11-29T02:15:22.841Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/61/f1/ee81806690a87dab5f5653c1f146c92bc066d7f4cebc603ef88eb9e13957/werkzeug-3.1.6.tar.gz", hash = "sha256:210c6bede5a420a913956b4791a7f4d6843a43b6fcee4dfa08a65e93007d0d25", size = 864736, upload-time = "2026-02-19T15:17:18.884Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/2f/f9/9e082990c2585c744734f85bec79b5dae5df9c974ffee58fe421652c8e91/werkzeug-3.1.4-py3-none-any.whl", hash = "sha256:2ad50fb9ed09cc3af22c54698351027ace879a0b60a3b5edf5730b2f7d876905", size = 224960, upload-time = "2025-11-29T02:15:21.13Z" },
+    { url = "https://files.pythonhosted.org/packages/4d/ec/d58832f89ede95652fd01f4f24236af7d32b70cab2196dfcc2d2fd13c5c2/werkzeug-3.1.6-py3-none-any.whl", hash = "sha256:7ddf3357bb9564e407607f988f683d72038551200c704012bb9a4c523d42f131", size = 225166, upload-time = "2026-02-19T15:17:17.475Z" },
 ]
 
 [[package]]

--- a/src/processor/pyproject.toml
+++ b/src/processor/pyproject.toml
@@ -62,4 +62,5 @@ prerelease = "allow"
 override-dependencies = [
     "urllib3==2.7.0",
     "authlib==1.7.1",
+    "idna==3.15",
 ]

--- a/src/processor/uv.lock
+++ b/src/processor/uv.lock
@@ -13,6 +13,7 @@ prerelease-mode = "allow"
 [manifest]
 overrides = [
     { name = "authlib", specifier = "==1.7.1" },
+    { name = "idna", specifier = "==3.15" },
     { name = "urllib3", specifier = "==2.7.0" },
 ]
 
@@ -1556,11 +1557,11 @@ wheels = [
 
 [[package]]
 name = "idna"
-version = "3.13"
+version = "3.15"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/ce/cc/762dfb036166873f0059f3b7de4565e1b5bc3d6f28a414c13da27e442f99/idna-3.13.tar.gz", hash = "sha256:585ea8fe5d69b9181ec1afba340451fba6ba764af97026f92a91d4eef164a242", size = 194210, upload-time = "2026-04-22T16:42:42.314Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/82/77/7b3966d0b9d1d31a36ddf1746926a11dface89a83409bf1483f0237aa758/idna-3.15.tar.gz", hash = "sha256:ca962446ea538f7092a95e057da437618e886f4d349216d2b1e294abfdb65fdc", size = 199245, upload-time = "2026-05-12T22:45:57.011Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/5d/13/ad7d7ca3808a898b4612b6fe93cde56b53f3034dcde235acb1f0e1df24c6/idna-3.13-py3-none-any.whl", hash = "sha256:892ea0cde124a99ce773decba204c5552b69c3c67ffd5f232eb7696135bc8bb3", size = 68629, upload-time = "2026-04-22T16:42:40.909Z" },
+    { url = "https://files.pythonhosted.org/packages/d2/23/408243171aa9aaba178d3e2559159c24c1171a641aa83b67bdd3394ead8e/idna-3.15-py3-none-any.whl", hash = "sha256:048adeaf8c2d788c40fee287673ccaa74c24ffd8dcf09ffa555a2fbb59f10ac8", size = 72340, upload-time = "2026-05-12T22:45:55.733Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Purpose

This pull request updates dependency versions in the `pyproject.toml` files for both the backend API and processor components. The main changes involve upgrading existing libraries and adding a new dependency to ensure compatibility and security.

Dependency updates:

* Upgraded `werkzeug` from version 3.1.4 to 3.1.6 in `src/backend-api/pyproject.toml` to include the latest fixes and improvements.
* Added `idna==3.15` as a dependency in both `src/backend-api/pyproject.toml` and `src/processor/pyproject.toml` for improved domain name handling and compatibility with other libraries. [[1]](diffhunk://#diff-3e12528a4c612597261fd8cb12f55fed6ff73b20f584cd7a512220d24e7e1e11L41-R47) [[2]](diffhunk://#diff-8af892a476110511a91a162e7fe684beb9436711fcb6fa4a84c36529017cd287R65)
* ...

## Does this introduce a breaking change?
<!-- Mark one with an "x". -->

- [ ] Yes
- [X] No
