### PR TITLE
fix: remove unused WorkflowEvent import and restore 'invalid content' retry check

### DIFF
--- a/src/processor/src/libs/agent_framework/azure_openai_response_retry.py
+++ b/src/processor/src/libs/agent_framework/azure_openai_response_retry.py
@@ -82,6 +82,14 @@ def _looks_like_rate_limit(error: BaseException) -> bool:
     if isinstance(status, int) and 500 <= status < 600:
         return True
 
+    # "The model produced invalid content" is a transient error from Azure OpenAI
+    # when the model output fails content/schema validation — worth retrying.
+    if any(
+        s in msg
+        for s in ["model produced invalid content", "invalid content"]
+    ):
+        return True
+
     cause = getattr(error, "__cause__", None)
     if cause and cause is not error:
         return _looks_like_rate_limit(cause)

--- a/src/processor/src/steps/migration_processor.py
+++ b/src/processor/src/steps/migration_processor.py
@@ -32,7 +32,7 @@ import time
 from datetime import datetime
 from typing import Any
 
-from agent_framework import Workflow, WorkflowBuilder, WorkflowEvent
+from agent_framework import Workflow, WorkflowBuilder
 
 from openai import AsyncAzureOpenAI
 


### PR DESCRIPTION
## Purpose

Addresses review comments from PR #273:

1. **Remove unused \WorkflowEvent\ import** from \migration_processor.py\ — it was imported but never used in code (only referenced in a comment), causing lint failure (F401).

2. **Restore 'model produced invalid content' transient error retry** in \zure_openai_response_retry.py\ — this check existed on \main\ but was accidentally dropped during the agent-framework 1.3.0 refactor in PR #272. Without it, structured response validation failures from Azure OpenAI won't be retried.

## Does this introduce a breaking change?

- [ ] Yes
- [X] No
