### PR TITLE
chore: Update RBAC Configuration to Reference Role IDs (follow-up)

### DIFF
--- a/infra/main.bicep
+++ b/infra/main.bicep
@@ -634,23 +634,23 @@ module storageAccount 'br/public:avm/res/storage/storage-account:0.20.0' = {
     supportsHttpsTrafficOnly: true
     roleAssignments: [
       {
-        roleDefinitionIdOrName: 'ba92f5b4-2d11-453d-a403-e96b0029c9fe' //'Storage Blob Data Contributor'
+        roleDefinitionIdOrName: 'ba92f5b4-2d11-453d-a403-e96b0029c9fe' // Storage Blob Data Contributor
         principalId: appIdentity.outputs.principalId
         principalType: 'ServicePrincipal'
       }
       {
-        roleDefinitionIdOrName: '974c5e8b-45b9-4653-ba55-5f855dd0fb88' //'Storage Queue Data Contributor'
+        roleDefinitionIdOrName: '974c5e8b-45b9-4653-ba55-5f855dd0fb88' // Storage Queue Data Contributor
         principalId: appIdentity.outputs.principalId
         principalType: 'ServicePrincipal'
       }
       // Add deployer permissions
       {
-        roleDefinitionIdOrName: 'ba92f5b4-2d11-453d-a403-e96b0029c9fe' //'Storage Blob Data Contributor'
+        roleDefinitionIdOrName: 'ba92f5b4-2d11-453d-a403-e96b0029c9fe' // Storage Blob Data Contributor
         principalId: deployingUserPrincipalId
         principalType: deployingUserType
       }
       {
-        roleDefinitionIdOrName: '974c5e8b-45b9-4653-ba55-5f855dd0fb88' //'Storage Queue Data Contributor'
+        roleDefinitionIdOrName: '974c5e8b-45b9-4653-ba55-5f855dd0fb88' // Storage Queue Data Contributor
         principalId: deployingUserPrincipalId
         principalType: deployingUserType
       }
@@ -721,7 +721,7 @@ module storageAccount 'br/public:avm/res/storage/storage-account:0.20.0' = {
 //========== Cosmos DB module ========== //
 var cosmosDbResourceName = 'cosmos-${solutionSuffix}'
 var cosmosDbZoneRedundantHaRegionPairs = {
-  australiaeast: 'uksouth' //'southeastasia'
+  australiaeast: 'uksouth' // southeastasia
   centralus: 'eastus2'
   eastasia: 'southeastasia'
   eastus: 'centralus'
@@ -847,13 +847,13 @@ module cosmosDb 'br/public:avm/res/document-db/database-account:0.15.0' = {
       {
         principalId: appIdentity.outputs.principalId
         principalType: 'ServicePrincipal'
-        roleDefinitionIdOrName: '5bd9cd88-fe45-4216-938b-f97437e15450' //'DocumentDB Account Contributor'
+        roleDefinitionIdOrName: '5bd9cd88-fe45-4216-938b-f97437e15450' // DocumentDB Account Contributor
       }
       // Add deployer for local debugging
       {
         principalId: deployingUserPrincipalId
         principalType: deployingUserType
-        roleDefinitionIdOrName: '5bd9cd88-fe45-4216-938b-f97437e15450' //'DocumentDB Account Contributor'
+        roleDefinitionIdOrName: '5bd9cd88-fe45-4216-938b-f97437e15450' // DocumentDB Account Contributor
       }
     ]
     // Create custom data plane role definition and assignment
@@ -935,28 +935,28 @@ module existingAiFoundryAiServicesDeployments 'modules/ai-services-deployments.b
       {
         principalId: appIdentity.outputs.principalId
         principalType: 'ServicePrincipal'
-        roleDefinitionIdOrName: 'a001fd3d-188f-4b5d-821b-7da978bf7442' //'Cognitive Services OpenAI Contributor'
+        roleDefinitionIdOrName: 'a001fd3d-188f-4b5d-821b-7da978bf7442' // Cognitive Services OpenAI Contributor
       }
       {
         principalId: appIdentity.outputs.principalId
         principalType: 'ServicePrincipal'
-        roleDefinitionIdOrName: '64702f94-c441-49e6-a78b-ef80e0188fee' //'Azure AI Developer'
+        roleDefinitionIdOrName: '64702f94-c441-49e6-a78b-ef80e0188fee' // Azure AI Developer
       }
       {
         principalId: appIdentity.outputs.principalId
         principalType: 'ServicePrincipal'
-        roleDefinitionIdOrName: '53ca6127-db72-4b80-b1b0-d745d6d5456d' //'Foundry User'
+        roleDefinitionIdOrName: '53ca6127-db72-4b80-b1b0-d745d6d5456d' // Foundry User
       }
       // Deployer permissions
       {
         principalId: deployingUserPrincipalId
         principalType: deployingUserType
-        roleDefinitionIdOrName: 'a001fd3d-188f-4b5d-821b-7da978bf7442' //'Cognitive Services OpenAI Contributor'
+        roleDefinitionIdOrName: 'a001fd3d-188f-4b5d-821b-7da978bf7442' // Cognitive Services OpenAI Contributor
       }
       {
         principalId: deployingUserPrincipalId
         principalType: deployingUserType
-        roleDefinitionIdOrName: 'a97b65f3-24c7-4388-baec-2e87135dc908' //'Cognitive Services User'
+        roleDefinitionIdOrName: 'a97b65f3-24c7-4388-baec-2e87135dc908' // Cognitive Services User
       }
     ]
   }
@@ -1012,7 +1012,7 @@ module aiFoundryAiServices 'br/public:avm/res/cognitive-services/account:0.13.2'
     roleAssignments: [
       // Service Principal permissions
       {
-        roleDefinitionIdOrName: 'a001fd3d-188f-4b5d-821b-7da978bf7442' //'Cognitive Services OpenAI Contributor'
+        roleDefinitionIdOrName: 'a001fd3d-188f-4b5d-821b-7da978bf7442' // Cognitive Services OpenAI Contributor
         principalId: appIdentity.outputs.principalId
         principalType: 'ServicePrincipal'
       }
@@ -1028,12 +1028,12 @@ module aiFoundryAiServices 'br/public:avm/res/cognitive-services/account:0.13.2'
       }
       // Deployer permissions for local debugging
       {
-        roleDefinitionIdOrName: 'a001fd3d-188f-4b5d-821b-7da978bf7442' //'Cognitive Services OpenAI Contributor'
+        roleDefinitionIdOrName: 'a001fd3d-188f-4b5d-821b-7da978bf7442' // Cognitive Services OpenAI Contributor
         principalId: deployingUserPrincipalId
         principalType: deployingUserType
       }
       {
-        roleDefinitionIdOrName: 'a97b65f3-24c7-4388-baec-2e87135dc908' //'Cognitive Services User'
+        roleDefinitionIdOrName: 'a97b65f3-24c7-4388-baec-2e87135dc908' // Cognitive Services User
         principalId: deployingUserPrincipalId
         principalType: deployingUserType
       }
@@ -1215,7 +1215,7 @@ module appConfiguration 'br/public:avm/res/app-configuration/configuration-store
       {
         principalId: appIdentity.outputs.principalId
         principalType: 'ServicePrincipal'
-        roleDefinitionIdOrName: '516239f1-63e1-4d78-a4de-a74fb236a071' //'App Configuration Data Reader'
+        roleDefinitionIdOrName: '516239f1-63e1-4d78-a4de-a74fb236a071' // App Configuration Data Reader
       }
     ]
     enableTelemetry: enableTelemetry

--- a/infra/main.bicep
+++ b/infra/main.bicep
@@ -634,23 +634,23 @@ module storageAccount 'br/public:avm/res/storage/storage-account:0.20.0' = {
     supportsHttpsTrafficOnly: true
     roleAssignments: [
       {
-        roleDefinitionIdOrName: 'Storage Blob Data Contributor'
+        roleDefinitionIdOrName: 'ba92f5b4-2d11-453d-a403-e96b0029c9fe' //'Storage Blob Data Contributor'
         principalId: appIdentity.outputs.principalId
         principalType: 'ServicePrincipal'
       }
       {
-        roleDefinitionIdOrName: 'Storage Queue Data Contributor'
+        roleDefinitionIdOrName: '974c5e8b-45b9-4653-ba55-5f855dd0fb88' //'Storage Queue Data Contributor'
         principalId: appIdentity.outputs.principalId
         principalType: 'ServicePrincipal'
       }
       // Add deployer permissions
       {
-        roleDefinitionIdOrName: 'Storage Blob Data Contributor'
+        roleDefinitionIdOrName: 'ba92f5b4-2d11-453d-a403-e96b0029c9fe' //'Storage Blob Data Contributor'
         principalId: deployingUserPrincipalId
         principalType: deployingUserType
       }
       {
-        roleDefinitionIdOrName: 'Storage Queue Data Contributor'
+        roleDefinitionIdOrName: '974c5e8b-45b9-4653-ba55-5f855dd0fb88' //'Storage Queue Data Contributor'
         principalId: deployingUserPrincipalId
         principalType: deployingUserType
       }
@@ -847,13 +847,13 @@ module cosmosDb 'br/public:avm/res/document-db/database-account:0.15.0' = {
       {
         principalId: appIdentity.outputs.principalId
         principalType: 'ServicePrincipal'
-        roleDefinitionIdOrName: 'DocumentDB Account Contributor'
+        roleDefinitionIdOrName: '5bd9cd88-fe45-4216-938b-f97437e15450' //'DocumentDB Account Contributor'
       }
       // Add deployer for local debugging
       {
         principalId: deployingUserPrincipalId
         principalType: deployingUserType
-        roleDefinitionIdOrName: 'DocumentDB Account Contributor'
+        roleDefinitionIdOrName: '5bd9cd88-fe45-4216-938b-f97437e15450' //'DocumentDB Account Contributor'
       }
     ]
     // Create custom data plane role definition and assignment
@@ -935,28 +935,28 @@ module existingAiFoundryAiServicesDeployments 'modules/ai-services-deployments.b
       {
         principalId: appIdentity.outputs.principalId
         principalType: 'ServicePrincipal'
-        roleDefinitionIdOrName: 'Cognitive Services OpenAI Contributor'
+        roleDefinitionIdOrName: 'a001fd3d-188f-4b5d-821b-7da978bf7442' //'Cognitive Services OpenAI Contributor'
       }
       {
         principalId: appIdentity.outputs.principalId
         principalType: 'ServicePrincipal'
-        roleDefinitionIdOrName: '64702f94-c441-49e6-a78b-ef80e0188fee'
+        roleDefinitionIdOrName: '64702f94-c441-49e6-a78b-ef80e0188fee' //'Azure AI Developer'
       }
       {
         principalId: appIdentity.outputs.principalId
         principalType: 'ServicePrincipal'
-        roleDefinitionIdOrName: '53ca6127-db72-4b80-b1b0-d745d6d5456d'
+        roleDefinitionIdOrName: '53ca6127-db72-4b80-b1b0-d745d6d5456d' //'Foundry User'
       }
       // Deployer permissions
       {
         principalId: deployingUserPrincipalId
         principalType: deployingUserType
-        roleDefinitionIdOrName: 'Cognitive Services OpenAI Contributor'
+        roleDefinitionIdOrName: 'a001fd3d-188f-4b5d-821b-7da978bf7442' //'Cognitive Services OpenAI Contributor'
       }
       {
         principalId: deployingUserPrincipalId
         principalType: deployingUserType
-        roleDefinitionIdOrName: 'Cognitive Services User'
+        roleDefinitionIdOrName: 'a97b65f3-24c7-4388-baec-2e87135dc908' //'Cognitive Services User'
       }
     ]
   }
@@ -1012,7 +1012,7 @@ module aiFoundryAiServices 'br/public:avm/res/cognitive-services/account:0.13.2'
     roleAssignments: [
       // Service Principal permissions
       {
-        roleDefinitionIdOrName: 'Cognitive Services OpenAI Contributor'
+        roleDefinitionIdOrName: 'a001fd3d-188f-4b5d-821b-7da978bf7442' //'Cognitive Services OpenAI Contributor'
         principalId: appIdentity.outputs.principalId
         principalType: 'ServicePrincipal'
       }
@@ -1028,12 +1028,12 @@ module aiFoundryAiServices 'br/public:avm/res/cognitive-services/account:0.13.2'
       }
       // Deployer permissions for local debugging
       {
-        roleDefinitionIdOrName: 'Cognitive Services OpenAI Contributor'
+        roleDefinitionIdOrName: 'a001fd3d-188f-4b5d-821b-7da978bf7442' //'Cognitive Services OpenAI Contributor'
         principalId: deployingUserPrincipalId
         principalType: deployingUserType
       }
       {
-        roleDefinitionIdOrName: 'Cognitive Services User'
+        roleDefinitionIdOrName: 'a97b65f3-24c7-4388-baec-2e87135dc908' //'Cognitive Services User'
         principalId: deployingUserPrincipalId
         principalType: deployingUserType
       }
@@ -1215,7 +1215,7 @@ module appConfiguration 'br/public:avm/res/app-configuration/configuration-store
       {
         principalId: appIdentity.outputs.principalId
         principalType: 'ServicePrincipal'
-        roleDefinitionIdOrName: 'App Configuration Data Reader'
+        roleDefinitionIdOrName: '516239f1-63e1-4d78-a4de-a74fb236a071' //'App Configuration Data Reader'
       }
     ]
     enableTelemetry: enableTelemetry

--- a/infra/main.json
+++ b/infra/main.json
@@ -5,8 +5,8 @@
   "metadata": {
     "_generator": {
       "name": "bicep",
-      "version": "0.43.8.12551",
-      "templateHash": "2561563027340256551"
+      "version": "0.44.1.10279",
+      "templateHash": "8615995649961363295"
     }
   },
   "parameters": {
@@ -4717,8 +4717,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.43.8.12551",
-              "templateHash": "4604761290796021104"
+              "version": "0.44.1.10279",
+              "templateHash": "8338582776365718527"
             }
           },
           "definitions": {
@@ -21723,22 +21723,22 @@
           "roleAssignments": {
             "value": [
               {
-                "roleDefinitionIdOrName": "Storage Blob Data Contributor",
+                "roleDefinitionIdOrName": "ba92f5b4-2d11-453d-a403-e96b0029c9fe",
                 "principalId": "[reference('appIdentity').outputs.principalId.value]",
                 "principalType": "ServicePrincipal"
               },
               {
-                "roleDefinitionIdOrName": "Storage Queue Data Contributor",
+                "roleDefinitionIdOrName": "974c5e8b-45b9-4653-ba55-5f855dd0fb88",
                 "principalId": "[reference('appIdentity').outputs.principalId.value]",
                 "principalType": "ServicePrincipal"
               },
               {
-                "roleDefinitionIdOrName": "Storage Blob Data Contributor",
+                "roleDefinitionIdOrName": "ba92f5b4-2d11-453d-a403-e96b0029c9fe",
                 "principalId": "[variables('deployingUserPrincipalId')]",
                 "principalType": "[variables('deployingUserType')]"
               },
               {
-                "roleDefinitionIdOrName": "Storage Queue Data Contributor",
+                "roleDefinitionIdOrName": "974c5e8b-45b9-4653-ba55-5f855dd0fb88",
                 "principalId": "[variables('deployingUserPrincipalId')]",
                 "principalType": "[variables('deployingUserType')]"
               }
@@ -27476,8 +27476,8 @@
       },
       "dependsOn": [
         "appIdentity",
-        "[format('avmPrivateDnsZones[{0}]', variables('dnsZoneIndex').storageBlob)]",
         "[format('avmPrivateDnsZones[{0}]', variables('dnsZoneIndex').storageQueue)]",
+        "[format('avmPrivateDnsZones[{0}]', variables('dnsZoneIndex').storageBlob)]",
         "virtualNetwork"
       ]
     },
@@ -27564,12 +27564,12 @@
               {
                 "principalId": "[reference('appIdentity').outputs.principalId.value]",
                 "principalType": "ServicePrincipal",
-                "roleDefinitionIdOrName": "DocumentDB Account Contributor"
+                "roleDefinitionIdOrName": "5bd9cd88-fe45-4216-938b-f97437e15450"
               },
               {
                 "principalId": "[variables('deployingUserPrincipalId')]",
                 "principalType": "[variables('deployingUserType')]",
-                "roleDefinitionIdOrName": "DocumentDB Account Contributor"
+                "roleDefinitionIdOrName": "5bd9cd88-fe45-4216-938b-f97437e15450"
               }
             ]
           },
@@ -31417,7 +31417,7 @@
               {
                 "principalId": "[reference('appIdentity').outputs.principalId.value]",
                 "principalType": "ServicePrincipal",
-                "roleDefinitionIdOrName": "Cognitive Services OpenAI Contributor"
+                "roleDefinitionIdOrName": "a001fd3d-188f-4b5d-821b-7da978bf7442"
               },
               {
                 "principalId": "[reference('appIdentity').outputs.principalId.value]",
@@ -31432,12 +31432,12 @@
               {
                 "principalId": "[variables('deployingUserPrincipalId')]",
                 "principalType": "[variables('deployingUserType')]",
-                "roleDefinitionIdOrName": "Cognitive Services OpenAI Contributor"
+                "roleDefinitionIdOrName": "a001fd3d-188f-4b5d-821b-7da978bf7442"
               },
               {
                 "principalId": "[variables('deployingUserPrincipalId')]",
                 "principalType": "[variables('deployingUserType')]",
-                "roleDefinitionIdOrName": "Cognitive Services User"
+                "roleDefinitionIdOrName": "a97b65f3-24c7-4388-baec-2e87135dc908"
               }
             ]
           }
@@ -31449,8 +31449,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.43.8.12551",
-              "templateHash": "13516349791985095953"
+              "version": "0.44.1.10279",
+              "templateHash": "8388310902652207735"
             }
           },
           "definitions": {
@@ -31855,7 +31855,7 @@
           "roleAssignments": {
             "value": [
               {
-                "roleDefinitionIdOrName": "Cognitive Services OpenAI Contributor",
+                "roleDefinitionIdOrName": "a001fd3d-188f-4b5d-821b-7da978bf7442",
                 "principalId": "[reference('appIdentity').outputs.principalId.value]",
                 "principalType": "ServicePrincipal"
               },
@@ -31870,12 +31870,12 @@
                 "principalType": "ServicePrincipal"
               },
               {
-                "roleDefinitionIdOrName": "Cognitive Services OpenAI Contributor",
+                "roleDefinitionIdOrName": "a001fd3d-188f-4b5d-821b-7da978bf7442",
                 "principalId": "[variables('deployingUserPrincipalId')]",
                 "principalType": "[variables('deployingUserType')]"
               },
               {
-                "roleDefinitionIdOrName": "Cognitive Services User",
+                "roleDefinitionIdOrName": "a97b65f3-24c7-4388-baec-2e87135dc908",
                 "principalId": "[variables('deployingUserPrincipalId')]",
                 "principalType": "[variables('deployingUserType')]"
               }
@@ -35199,9 +35199,9 @@
       },
       "dependsOn": [
         "aiFoundryAiServices",
+        "[format('avmPrivateDnsZones[{0}]', variables('dnsZoneIndex').openAI)]",
         "[format('avmPrivateDnsZones[{0}]', variables('dnsZoneIndex').aiServices)]",
         "[format('avmPrivateDnsZones[{0}]', variables('dnsZoneIndex').cognitiveServices)]",
-        "[format('avmPrivateDnsZones[{0}]', variables('dnsZoneIndex').openAI)]",
         "virtualNetwork"
       ]
     },
@@ -35238,8 +35238,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.43.8.12551",
-              "templateHash": "17583277036649944863"
+              "version": "0.44.1.10279",
+              "templateHash": "16726486764770261194"
             }
           },
           "parameters": {
@@ -35461,7 +35461,7 @@
               {
                 "principalId": "[reference('appIdentity').outputs.principalId.value]",
                 "principalType": "ServicePrincipal",
-                "roleDefinitionIdOrName": "App Configuration Data Reader"
+                "roleDefinitionIdOrName": "516239f1-63e1-4d78-a4de-a74fb236a071"
               }
             ]
           },

--- a/infra/main_custom.bicep
+++ b/infra/main_custom.bicep
@@ -1172,7 +1172,7 @@ module appConfiguration 'br/public:avm/res/app-configuration/configuration-store
       {
         principalId: appIdentity.outputs.principalId
         principalType: 'ServicePrincipal'
-        roleDefinitionIdOrName: 'App Configuration Data Reader'
+        roleDefinitionIdOrName: '516239f1-63e1-4d78-a4de-a74fb236a071' //'App Configuration Data Reader'
       }
     ]
     enableTelemetry: enableTelemetry

--- a/infra/main_custom.bicep
+++ b/infra/main_custom.bicep
@@ -612,12 +612,12 @@ module storageAccount 'br/public:avm/res/storage/storage-account:0.20.0' = {
     supportsHttpsTrafficOnly: true
     roleAssignments: [
       {
-        roleDefinitionIdOrName: 'Storage Blob Data Contributor'
+        roleDefinitionIdOrName: 'ba92f5b4-2d11-453d-a403-e96b0029c9fe' //'Storage Blob Data Contributor'
         principalId: appIdentity.outputs.principalId
         principalType: 'ServicePrincipal'
       }
       {
-        roleDefinitionIdOrName: 'Storage Queue Data Contributor'
+        roleDefinitionIdOrName: '974c5e8b-45b9-4653-ba55-5f855dd0fb88' //'Storage Queue Data Contributor'
         principalId: appIdentity.outputs.principalId
         principalType: 'ServicePrincipal'
       }
@@ -806,7 +806,7 @@ module cosmosDb 'br/public:avm/res/document-db/database-account:0.15.0' = {
       {
         principalId: appIdentity.outputs.principalId
         principalType: 'ServicePrincipal'
-        roleDefinitionIdOrName: 'DocumentDB Account Contributor'
+        roleDefinitionIdOrName: '5bd9cd88-fe45-4216-938b-f97437e15450' //'DocumentDB Account Contributor'
       }
     ]
     // Create custom data plane role definition and assignment
@@ -902,7 +902,7 @@ module existingAiFoundryAiServicesDeployments 'modules/ai-services-deployments.b
       {
         principalId: appIdentity.outputs.principalId
         principalType: 'ServicePrincipal'
-        roleDefinitionIdOrName: 'Cognitive Services OpenAI Contributor'
+        roleDefinitionIdOrName: 'a001fd3d-188f-4b5d-821b-7da978bf7442' //'Cognitive Services OpenAI Contributor'
       }
       {
         principalId: appIdentity.outputs.principalId
@@ -956,7 +956,7 @@ module aiFoundryAiServices 'br/public:avm/res/cognitive-services/account:0.13.2'
     roleAssignments: [
       // Service Principal permissions
       {
-        roleDefinitionIdOrName: 'Cognitive Services OpenAI Contributor'
+        roleDefinitionIdOrName: 'a001fd3d-188f-4b5d-821b-7da978bf7442' //'Cognitive Services OpenAI Contributor'
         principalId: appIdentity.outputs.principalId
         principalType: 'ServicePrincipal'
       }
@@ -972,12 +972,12 @@ module aiFoundryAiServices 'br/public:avm/res/cognitive-services/account:0.13.2'
       }
       // Deployer permissions for local debugging
       {
-        roleDefinitionIdOrName: 'Cognitive Services OpenAI Contributor'
+        roleDefinitionIdOrName: 'a001fd3d-188f-4b5d-821b-7da978bf7442' //'Cognitive Services OpenAI Contributor'
         principalId: deployingUserPrincipalId
         principalType: 'User'
       }
       {
-        roleDefinitionIdOrName: 'Cognitive Services User'
+        roleDefinitionIdOrName: 'a97b65f3-24c7-4388-baec-2e87135dc908' //'Cognitive Services User'
         principalId: deployingUserPrincipalId
         principalType: 'User'
       }

--- a/infra/main_custom.bicep
+++ b/infra/main_custom.bicep
@@ -612,12 +612,12 @@ module storageAccount 'br/public:avm/res/storage/storage-account:0.20.0' = {
     supportsHttpsTrafficOnly: true
     roleAssignments: [
       {
-        roleDefinitionIdOrName: 'ba92f5b4-2d11-453d-a403-e96b0029c9fe' //'Storage Blob Data Contributor'
+        roleDefinitionIdOrName: 'ba92f5b4-2d11-453d-a403-e96b0029c9fe' // Storage Blob Data Contributor
         principalId: appIdentity.outputs.principalId
         principalType: 'ServicePrincipal'
       }
       {
-        roleDefinitionIdOrName: '974c5e8b-45b9-4653-ba55-5f855dd0fb88' //'Storage Queue Data Contributor'
+        roleDefinitionIdOrName: '974c5e8b-45b9-4653-ba55-5f855dd0fb88' // Storage Queue Data Contributor
         principalId: appIdentity.outputs.principalId
         principalType: 'ServicePrincipal'
       }
@@ -688,7 +688,7 @@ module storageAccount 'br/public:avm/res/storage/storage-account:0.20.0' = {
 //========== Cosmos DB module ========== //
 var cosmosDbResourceName = 'cosmos-${solutionSuffix}'
 var cosmosDbZoneRedundantHaRegionPairs = {
-  australiaeast: 'uksouth' //'southeastasia'
+  australiaeast: 'uksouth' // southeastasia
   centralus: 'eastus2'
   eastasia: 'southeastasia'
   eastus: 'centralus'
@@ -806,7 +806,7 @@ module cosmosDb 'br/public:avm/res/document-db/database-account:0.15.0' = {
       {
         principalId: appIdentity.outputs.principalId
         principalType: 'ServicePrincipal'
-        roleDefinitionIdOrName: '5bd9cd88-fe45-4216-938b-f97437e15450' //'DocumentDB Account Contributor'
+        roleDefinitionIdOrName: '5bd9cd88-fe45-4216-938b-f97437e15450' // DocumentDB Account Contributor
       }
     ]
     // Create custom data plane role definition and assignment
@@ -902,7 +902,7 @@ module existingAiFoundryAiServicesDeployments 'modules/ai-services-deployments.b
       {
         principalId: appIdentity.outputs.principalId
         principalType: 'ServicePrincipal'
-        roleDefinitionIdOrName: 'a001fd3d-188f-4b5d-821b-7da978bf7442' //'Cognitive Services OpenAI Contributor'
+        roleDefinitionIdOrName: 'a001fd3d-188f-4b5d-821b-7da978bf7442' // Cognitive Services OpenAI Contributor
       }
       {
         principalId: appIdentity.outputs.principalId
@@ -956,7 +956,7 @@ module aiFoundryAiServices 'br/public:avm/res/cognitive-services/account:0.13.2'
     roleAssignments: [
       // Service Principal permissions
       {
-        roleDefinitionIdOrName: 'a001fd3d-188f-4b5d-821b-7da978bf7442' //'Cognitive Services OpenAI Contributor'
+        roleDefinitionIdOrName: 'a001fd3d-188f-4b5d-821b-7da978bf7442' // Cognitive Services OpenAI Contributor
         principalId: appIdentity.outputs.principalId
         principalType: 'ServicePrincipal'
       }
@@ -972,12 +972,12 @@ module aiFoundryAiServices 'br/public:avm/res/cognitive-services/account:0.13.2'
       }
       // Deployer permissions for local debugging
       {
-        roleDefinitionIdOrName: 'a001fd3d-188f-4b5d-821b-7da978bf7442' //'Cognitive Services OpenAI Contributor'
+        roleDefinitionIdOrName: 'a001fd3d-188f-4b5d-821b-7da978bf7442' // Cognitive Services OpenAI Contributor
         principalId: deployingUserPrincipalId
         principalType: 'User'
       }
       {
-        roleDefinitionIdOrName: 'a97b65f3-24c7-4388-baec-2e87135dc908' //'Cognitive Services User'
+        roleDefinitionIdOrName: 'a97b65f3-24c7-4388-baec-2e87135dc908' // Cognitive Services User
         principalId: deployingUserPrincipalId
         principalType: 'User'
       }
@@ -1172,7 +1172,7 @@ module appConfiguration 'br/public:avm/res/app-configuration/configuration-store
       {
         principalId: appIdentity.outputs.principalId
         principalType: 'ServicePrincipal'
-        roleDefinitionIdOrName: '516239f1-63e1-4d78-a4de-a74fb236a071' //'App Configuration Data Reader'
+        roleDefinitionIdOrName: '516239f1-63e1-4d78-a4de-a74fb236a071' // App Configuration Data Reader
       }
     ]
     enableTelemetry: enableTelemetry


### PR DESCRIPTION
## Purpose
<!-- Describe the intention of the changes being proposed. What problem does it solve or functionality does it add? -->
Update the RBAC configuration so that every role assignment references its Azure built-in role **definition ID (GUID)** instead of the role display name. Referencing roles by GUID avoids ambiguity and intermittent lookup/deployment failures that can occur when resolving roles by display name.

Scope of changes:
* `infra/main.bicep` — convert all `roleDefinitionIdOrName` role-name values to their role definition GUIDs (Storage Blob/Queue Data Contributor, DocumentDB Account Contributor, Cognitive Services OpenAI Contributor / User, App Configuration Data Reader, etc.), each annotated with an inline `// Role Name` comment.
* `infra/main_custom.bicep` — same conversion, including the previously missed `App Configuration Data Reader` assignment.
* `infra/main.json` — regenerated ARM output reflecting the above Bicep changes.
* Inline role-name comments use the `// Role Name` format (space after `//`, no quotes) for readability and consistency with the rest of the files.

## Does this introduce a breaking change?
<!-- Mark one with an "x". -->

- [ ] Yes
- [x] No

## Golden Path Validation
- [x] I have tested the primary workflows (the "golden path") to ensure they function correctly without errors.

## Deployment Validation
- [x] I have validated the deployment process successfully and all services are running as expected with this change.

## What to Check
Verify that the following are valid
* Every `roleDefinitionIdOrName` across `infra/main.bicep`, `infra/main_custom.bicep`, and `infra/main.json` references a role definition GUID (no remaining display-name references).
* Each GUID maps to the correct Azure built-in role (see the inline `// Role Name` comments).
* `infra/main.json` is consistent with the regenerated Bicep.

## Other Information

<!-- Add any other helpful information that may be needed here. -->
Companion change to the Content Processing Solution Accelerator PR applying the same role-ID convention.
