### PR TITLE
feat: implement dedicated Azure Container Registry 

### DIFF
--- a/README.md
+++ b/README.md
@@ -205,10 +205,10 @@ flowchart TB
    %% LLM usage
    PROC -->|LLM call| AOAI
 
-   %% Image pulls
-   ACR -->|Pull image| FE
-   ACR -->|Pull image| API
-   ACR -->|Pull image| PROC
+   %% Image pulls (identity-based, AcrPull via managed identity - no anonymous pull)
+   ACR -->|Pull image · AcrPull| FE
+   ACR -->|Pull image · AcrPull| API
+   ACR -->|Pull image · AcrPull| PROC
 
    %% Identity usage
    ID -.-> FE

--- a/azure.yaml
+++ b/azure.yaml
@@ -30,7 +30,7 @@ hooks:
       shell: pwsh
       run: |  
         Write-Host "==> Building and pushing container images to the dedicated ACR (remote build)"
-        pwsh ./scripts/deploy_container_images.ps1
+        ./scripts/deploy_container_images.ps1
         Write-Host "-----"
         Write-Host "🧭 Web App Details:"
         Write-Host "✅ Name: $env:CONTAINER_WEB_APP_NAME"

--- a/azure.yaml
+++ b/azure.yaml
@@ -12,6 +12,8 @@ hooks:
     posix:
       shell: sh
       run: |  
+        echo "==> Building and pushing container images to the dedicated ACR (remote build)"
+        sh ./scripts/deploy_container_images.sh
         echo "-----"
         echo "🧭 Web App Details:"
         echo "✅ Name: $CONTAINER_WEB_APP_NAME"
@@ -27,6 +29,8 @@ hooks:
     windows:
       shell: pwsh
       run: |  
+        Write-Host "==> Building and pushing container images to the dedicated ACR (remote build)"
+        pwsh ./scripts/deploy_container_images.ps1
         Write-Host "-----"
         Write-Host "🧭 Web App Details:"
         Write-Host "✅ Name: $env:CONTAINER_WEB_APP_NAME"

--- a/azure.yaml
+++ b/azure.yaml
@@ -13,7 +13,7 @@ hooks:
       shell: sh
       run: |  
         echo "==> Building and pushing container images to the dedicated ACR (remote build)"
-        sh ./scripts/deploy_container_images.sh
+        bash ./scripts/deploy_container_images.sh
         echo "-----"
         echo "🧭 Web App Details:"
         echo "✅ Name: $CONTAINER_WEB_APP_NAME"

--- a/infra/main.bicep
+++ b/infra/main.bicep
@@ -41,11 +41,16 @@ param azureAiServiceLocation string
 
 
 
-@description('Optional. The endpoint (excluding https://) of an existing container registry. This is the `loginServer` when using Azure Container Registry.')
-param containerRegistryEndpoint string = 'containermigrationacr.azurecr.io'
+@description('Optional. [Deprecated] The endpoint (excluding https://) of an existing container registry. Retained only for backward compatibility with existing parameter files/pipelines; each deployment now provisions its own dedicated Azure Container Registry and no longer depends on a shared/public registry.')
+#disable-next-line no-unused-params
+param containerRegistryEndpoint string = ''
 
 @description('Optional. The image tag to use for container images. Defaults to "latest_v2".')
 param imageTag string = 'latest_v2'
+
+@description('''Optional. Placeholder container image used to initially provision the container apps.
+The dedicated Azure Container Registry is empty right after infrastructure provisioning, so a public image is used as the default allowed image until the post-deployment script (scripts/deploy_container_images.*) builds and pushes the deployment-specific images and updates the apps. Defaults to the Azure Container Apps quickstart image.''')
+param placeholderContainerImage string = 'mcr.microsoft.com/k8se/quickstart:latest'
 
 @minLength(1)
 @allowed(['Standard', 'GlobalStandard'])
@@ -217,6 +222,36 @@ module appIdentity 'br/public:avm/res/managed-identity/user-assigned-identity:0.
     location: solutionLocation
     tags: allTags
     enableTelemetry: enableTelemetry
+  }
+}
+
+// ========== Dedicated Azure Container Registry ========== //
+// Each deployment provisions its own ACR instead of relying on a shared/public
+// registry with anonymous pull. Images are pulled using identity-based
+// authentication (AcrPull role granted to the application managed identity).
+var containerRegistryName = take('cr${solutionSuffix}', 50)
+module containerRegistry './modules/containerRegistry.bicep' = {
+  name: take('module.container-registry.${solutionSuffix}', 64)
+  params: {
+    name: containerRegistryName
+    location: solutionLocation
+    tags: allTags
+    // Premium SKU in WAF/private-networking mode (supports higher throughput and
+    // future private endpoints). Public network access is kept Enabled in both
+    // modes so remote `az acr build` (ACR Tasks) and managed-identity pulls work;
+    // AzureServices bypass lets trusted ACR Tasks reach the registry.
+    sku: enablePrivateNetworking ? 'Premium' : 'Standard'
+    publicNetworkAccess: 'Enabled'
+    networkRuleBypassOptions: 'AzureServices'
+    // Application managed identity gets AcrPull for identity-based image pulls.
+    acrPullPrincipalIds: [
+      appIdentity.outputs.principalId
+    ]
+    // Deployer gets a registry-scoped AcrPush role so it can push/pull images
+    // from the post-deployment script. Remote build (az acr build) additionally
+    // needs scheduleRun/action, which the deployer holds via its higher-scope role.
+    buildPrincipalId: deployingUserPrincipalId
+    buildPrincipalType: deployingUserType
   }
 }
 
@@ -1335,10 +1370,16 @@ module containerAppBackend 'br/public:avm/res/app/container-app:0.18.1' = {
         appIdentity.outputs.resourceId
       ]
     }
+    registries: [
+      {
+        server: containerRegistry.outputs.loginServer
+        identity: appIdentity.outputs.resourceId
+      }
+    ]
     containers: [
       {
         name: 'backend-api'
-        image: '${containerRegistryEndpoint}/backend-api:${imageTag}'
+        image: placeholderContainerImage
         env: concat(
           [
             {
@@ -1422,10 +1463,16 @@ module containerAppFrontend 'br/public:avm/res/app/container-app:0.18.1' = {
         appIdentity.outputs.resourceId
       ]
     }
+    registries: [
+      {
+        server: containerRegistry.outputs.loginServer
+        identity: appIdentity.outputs.resourceId
+      }
+    ]
     containers: [
       {
         name: 'frontend'
-        image: '${containerRegistryEndpoint}/frontend:${imageTag}'
+        image: placeholderContainerImage
         env: [
           {
             name: 'API_URL'
@@ -1490,10 +1537,16 @@ module containerAppProcessor 'br/public:avm/res/app/container-app:0.18.1' = {
         appIdentity.outputs.resourceId
       ]
     }
+    registries: [
+      {
+        server: containerRegistry.outputs.loginServer
+        identity: appIdentity.outputs.resourceId
+      }
+    ]
     containers: [
       {
         name: 'processor'
-        image: '${containerRegistryEndpoint}/processor:${imageTag}'
+        image: placeholderContainerImage
         env: concat(
           [
             {
@@ -1571,6 +1624,18 @@ output AZURE_SUBSCRIPTION_ID string = subscription().subscriptionId
 
 @description('The Azure resource group name.')
 output AZURE_RESOURCE_GROUP string = resourceGroup().name
+
+@description('The name of the dedicated Azure Container Registry.')
+output AZURE_CONTAINER_REGISTRY_NAME string = containerRegistry.outputs.name
+
+@description('The login server (endpoint) of the dedicated Azure Container Registry.')
+output AZURE_CONTAINER_REGISTRY_ENDPOINT string = containerRegistry.outputs.loginServer
+
+@description('The name of the processor container app.')
+output CONTAINER_PROCESSOR_APP_NAME string = containerAppProcessor.outputs.name
+
+@description('The image tag used for deployment-specific container images.')
+output AZURE_ENV_IMAGE_TAG string = imageTag
 
 // Log deployer information for debugging
 output deployerObjectId string = deployingUserPrincipalId

--- a/infra/modules/containerRegistry.bicep
+++ b/infra/modules/containerRegistry.bicep
@@ -1,0 +1,113 @@
+metadata name = 'Dedicated Azure Container Registry'
+metadata description = '''Provisions a dedicated Azure Container Registry (ACR) for a single deployment and configures identity-based authentication.
+Admin user and anonymous pull are disabled. The provided application managed identity principals are granted the AcrPull role, and the deployer is granted a registry-scoped AcrPush role so it can push/pull images (remote builds via `az acr build` additionally rely on the deployer's higher-scope role for scheduleRun/action).'''
+
+@description('Required. Name of the Azure Container Registry. Must be globally unique and 5-50 alphanumeric characters.')
+@maxLength(50)
+param name string
+
+@description('Optional. Azure region for the registry. Defaults to the resource group location.')
+param location string = resourceGroup().location
+
+@description('Optional. Tags to apply to the registry.')
+param tags object = {}
+
+@description('Optional. SKU for the registry. Premium is required for private networking. Defaults to Standard.')
+@allowed([
+  'Basic'
+  'Standard'
+  'Premium'
+])
+param sku string = 'Standard'
+
+@description('Optional. Public network access for the registry. Defaults to Enabled. Note: `az acr build` (ACR Tasks quick builds) and Container Apps image pulls require reachability; disabling public access requires VNet agent pools and private endpoints, so it is left Enabled by default for both WAF and non-WAF deployments.')
+@allowed([
+  'Enabled'
+  'Disabled'
+])
+param publicNetworkAccess string = 'Enabled'
+
+@description('Optional. Whether to allow trusted Azure services (e.g. ACR Tasks used by `az acr build`) to bypass network rules. Defaults to AzureServices.')
+@allowed([
+  'AzureServices'
+  'None'
+])
+param networkRuleBypassOptions string = 'AzureServices'
+
+@description('Optional. Principal IDs (managed identities) to grant the AcrPull role so they can pull images using identity-based authentication.')
+param acrPullPrincipalIds array = []
+
+@description('Optional. Principal ID (e.g. the deployer) to grant a registry-scoped AcrPush role so it can push/pull images. Leave empty to skip.')
+param buildPrincipalId string = ''
+
+@description('Optional. Principal type for the build principal.')
+@allowed([
+  'Device'
+  'ForeignGroup'
+  'Group'
+  'ServicePrincipal'
+  'User'
+])
+param buildPrincipalType string = 'User'
+
+// AcrPull role definition ID (allows pulling images).
+var acrPullRoleDefinitionId = '7f951dda-4ed3-4680-a7ca-43fe172d538d'
+// AcrPush role definition ID (least-privilege push/pull for the deployer).
+// Note: az acr build (ACR Tasks remote build) additionally needs
+// scheduleRun/action, which the deployer holds via its higher-scope role
+// (e.g. Owner/Contributor on the subscription or resource group used by azd).
+var acrPushRoleDefinitionId = '8311e382-0749-4cb8-b61a-304f252e45ec'
+
+resource registry 'Microsoft.ContainerRegistry/registries@2023-07-01' = {
+  name: name
+  location: location
+  tags: tags
+  sku: {
+    name: sku
+  }
+  properties: {
+    // Identity-based authentication only - no admin credentials.
+    adminUserEnabled: false
+    // Explicitly disable anonymous pull; access requires an authenticated identity.
+    anonymousPullEnabled: false
+    publicNetworkAccess: publicNetworkAccess
+    networkRuleBypassOptions: networkRuleBypassOptions
+  }
+}
+
+resource acrPullRoleAssignments 'Microsoft.Authorization/roleAssignments@2022-04-01' = [
+  for principalId in acrPullPrincipalIds: {
+    name: guid(registry.id, principalId, acrPullRoleDefinitionId)
+    scope: registry
+    properties: {
+      roleDefinitionId: subscriptionResourceId(
+        'Microsoft.Authorization/roleDefinitions',
+        acrPullRoleDefinitionId
+      )
+      principalId: principalId
+      principalType: 'ServicePrincipal'
+    }
+  }
+]
+
+resource acrBuildRoleAssignment 'Microsoft.Authorization/roleAssignments@2022-04-01' = if (!empty(buildPrincipalId)) {
+  name: guid(registry.id, buildPrincipalId, acrPushRoleDefinitionId)
+  scope: registry
+  properties: {
+    roleDefinitionId: subscriptionResourceId(
+      'Microsoft.Authorization/roleDefinitions',
+      acrPushRoleDefinitionId
+    )
+    principalId: buildPrincipalId
+    principalType: buildPrincipalType
+  }
+}
+
+@description('The resource ID of the container registry.')
+output resourceId string = registry.id
+
+@description('The name of the container registry.')
+output name string = registry.name
+
+@description('The login server (endpoint) of the container registry, e.g. myregistry.azurecr.io.')
+output loginServer string = registry.properties.loginServer

--- a/scripts/deploy_container_images.ps1
+++ b/scripts/deploy_container_images.ps1
@@ -74,6 +74,11 @@ if (-not (Get-Command az -ErrorAction SilentlyContinue)) {
 # Ensure the Azure CLI has a valid, non-expired login. `az acr build` and
 # `az containerapp update` authenticate via the az CLI (separate from azd), so a
 # stale/expired token here would otherwise fail part-way through the build.
+if (-not (Get-Command az -ErrorAction SilentlyContinue)) {
+    Write-Error "Azure CLI (az) is not installed or not on PATH. Install Azure CLI and re-run this script."
+    exit 1
+}
+
 az account show --output none 2>$null
 if ($LASTEXITCODE -ne 0) {
     Write-Error "Azure CLI is not authenticated or its token has expired. Run 'az login' (add '--tenant <tenant-id>' if needed) and re-run this script."

--- a/scripts/deploy_container_images.ps1
+++ b/scripts/deploy_container_images.ps1
@@ -1,0 +1,119 @@
+<#
+.SYNOPSIS
+    Separate post-deployment script (Windows / PowerShell) that runs FIRST,
+    before any existing post-deployment scripts.
+
+.DESCRIPTION
+    Builds the deployment-specific container images using Azure Container
+    Registry *remote* builds (az acr build - no local Docker required) and
+    pushes them to the dedicated, per-deployment ACR. It then updates the
+    Container Apps to use the freshly pushed images.
+
+    This does NOT depend on a shared/public registry or anonymous pull. Image
+    pulls at runtime use identity-based authentication (the app's managed
+    identity has the AcrPull role on the dedicated ACR).
+#>
+
+$ErrorActionPreference = 'Stop'
+
+Write-Host "==> [deploy_container_images] Building and pushing images to the dedicated ACR (remote build)"
+
+# ---------------------------------------------------------------------------
+# Resolve required values. azd exports deployment outputs as environment
+# variables inside hooks; fall back to `azd env get-values` if needed.
+# ---------------------------------------------------------------------------
+$AcrName          = $env:AZURE_CONTAINER_REGISTRY_NAME
+$RegistryEndpoint = $env:AZURE_CONTAINER_REGISTRY_ENDPOINT
+$ResourceGroup    = $env:AZURE_RESOURCE_GROUP
+$ImageTag         = if ($env:AZURE_ENV_IMAGE_TAG) { $env:AZURE_ENV_IMAGE_TAG } else { 'latest_v2' }
+$BackendApp       = $env:CONTAINER_API_APP_NAME
+$FrontendApp      = $env:CONTAINER_WEB_APP_NAME
+$ProcessorApp     = $env:CONTAINER_PROCESSOR_APP_NAME
+
+if ([string]::IsNullOrEmpty($AcrName) -or [string]::IsNullOrEmpty($ResourceGroup)) {
+    if (Get-Command azd -ErrorAction SilentlyContinue) {
+        Write-Host "==> Loading missing values from 'azd env get-values'"
+        foreach ($line in (azd env get-values)) {
+            if ($line -match '^(?<k>[A-Za-z0-9_]+)="?(?<v>.*?)"?$') {
+                $k = $Matches['k']; $v = $Matches['v']
+                switch ($k) {
+                    'AZURE_CONTAINER_REGISTRY_NAME'     { if (-not $AcrName)          { $AcrName = $v } }
+                    'AZURE_CONTAINER_REGISTRY_ENDPOINT' { if (-not $RegistryEndpoint) { $RegistryEndpoint = $v } }
+                    'AZURE_RESOURCE_GROUP'              { if (-not $ResourceGroup)    { $ResourceGroup = $v } }
+                    'AZURE_ENV_IMAGE_TAG'               { if (-not $env:AZURE_ENV_IMAGE_TAG) { $ImageTag = $v } }
+                    'CONTAINER_API_APP_NAME'            { if (-not $BackendApp)       { $BackendApp = $v } }
+                    'CONTAINER_WEB_APP_NAME'            { if (-not $FrontendApp)      { $FrontendApp = $v } }
+                    'CONTAINER_PROCESSOR_APP_NAME'      { if (-not $ProcessorApp)     { $ProcessorApp = $v } }
+                }
+            }
+        }
+    }
+}
+
+# Derive the login server from the registry name if it was not provided.
+if ([string]::IsNullOrEmpty($RegistryEndpoint)) {
+    $RegistryEndpoint = "$AcrName.azurecr.io"
+}
+
+$missing = @()
+if ([string]::IsNullOrEmpty($AcrName))       { $missing += 'AZURE_CONTAINER_REGISTRY_NAME' }
+if ([string]::IsNullOrEmpty($ResourceGroup)) { $missing += 'AZURE_RESOURCE_GROUP' }
+if ($missing.Count -gt 0) {
+    Write-Error "Missing required deployment values: $($missing -join ', '). Ensure infrastructure has been provisioned (azd provision) first."
+    exit 1
+}
+
+# Ensure the Azure CLI has a valid, non-expired login. `az acr build` and
+# `az containerapp update` authenticate via the az CLI (separate from azd), so a
+# stale/expired token here would otherwise fail part-way through the build.
+az account show --output none 2>$null
+if ($LASTEXITCODE -ne 0) {
+    Write-Error "Azure CLI is not authenticated or its token has expired. Run 'az login' (add '--tenant <tenant-id>' if needed) and re-run this script."
+    exit 1
+}
+
+# Resolve the repository root (this script lives in <root>/scripts).
+$ScriptDir = Split-Path -Parent $MyInvocation.MyCommand.Path
+$RootDir   = Split-Path -Parent $ScriptDir
+
+Write-Host "    Registry        : $RegistryEndpoint ($AcrName)"
+Write-Host "    Resource group  : $ResourceGroup"
+Write-Host "    Image tag       : $ImageTag"
+
+function Build-Image {
+    param([string]$ImageName, [string]$ContextDir)
+    Write-Host "==> Remote build (az acr build): ${ImageName}:$ImageTag"
+    az acr build `
+        --registry $AcrName `
+        --image "${ImageName}:$ImageTag" `
+        --file (Join-Path $ContextDir 'Dockerfile') `
+        $ContextDir
+    if ($LASTEXITCODE -ne 0) { throw "az acr build failed for $ImageName" }
+}
+
+function Update-App {
+    param([string]$AppName, [string]$ImageName)
+    if ([string]::IsNullOrEmpty($AppName)) {
+        Write-Host "WARN: Container app name for '$ImageName' not set; skipping image update."
+        return
+    }
+    Write-Host "==> Updating container app '$AppName' -> $RegistryEndpoint/${ImageName}:$ImageTag"
+    az containerapp update `
+        --name $AppName `
+        --resource-group $ResourceGroup `
+        --image "$RegistryEndpoint/${ImageName}:$ImageTag" `
+        --output none
+    if ($LASTEXITCODE -ne 0) { throw "az containerapp update failed for $AppName" }
+}
+
+# Build & push all images to the dedicated ACR.
+Build-Image -ImageName 'backend-api' -ContextDir (Join-Path $RootDir 'src/backend-api')
+Build-Image -ImageName 'processor'   -ContextDir (Join-Path $RootDir 'src/processor')
+Build-Image -ImageName 'frontend'    -ContextDir (Join-Path $RootDir 'src/frontend')
+
+# Point the Container Apps at the freshly built images.
+Update-App -AppName $BackendApp   -ImageName 'backend-api'
+Update-App -AppName $ProcessorApp -ImageName 'processor'
+Update-App -AppName $FrontendApp  -ImageName 'frontend'
+
+Write-Host "==> [deploy_container_images] Completed successfully."

--- a/scripts/deploy_container_images.ps1
+++ b/scripts/deploy_container_images.ps1
@@ -30,7 +30,11 @@ $BackendApp       = $env:CONTAINER_API_APP_NAME
 $FrontendApp      = $env:CONTAINER_WEB_APP_NAME
 $ProcessorApp     = $env:CONTAINER_PROCESSOR_APP_NAME
 
-if ([string]::IsNullOrEmpty($AcrName) -or [string]::IsNullOrEmpty($ResourceGroup)) {
+# Load values from `azd env get-values` when any required value is missing. This
+# covers not just the registry/resource group but also the container app names
+# and registry endpoint, so a partially-populated environment does not silently
+# skip image updates and leave apps on the placeholder image.
+if ([string]::IsNullOrEmpty($AcrName) -or [string]::IsNullOrEmpty($ResourceGroup) -or [string]::IsNullOrEmpty($RegistryEndpoint) -or [string]::IsNullOrEmpty($BackendApp) -or [string]::IsNullOrEmpty($FrontendApp) -or [string]::IsNullOrEmpty($ProcessorApp)) {
     if (Get-Command azd -ErrorAction SilentlyContinue) {
         Write-Host "==> Loading missing values from 'azd env get-values'"
         foreach ($line in (azd env get-values)) {
@@ -74,11 +78,6 @@ if (-not (Get-Command az -ErrorAction SilentlyContinue)) {
 # Ensure the Azure CLI has a valid, non-expired login. `az acr build` and
 # `az containerapp update` authenticate via the az CLI (separate from azd), so a
 # stale/expired token here would otherwise fail part-way through the build.
-if (-not (Get-Command az -ErrorAction SilentlyContinue)) {
-    Write-Error "Azure CLI (az) is not installed or not on PATH. Install Azure CLI and re-run this script."
-    exit 1
-}
-
 az account show --output none 2>$null
 if ($LASTEXITCODE -ne 0) {
     Write-Error "Azure CLI is not authenticated or its token has expired. Run 'az login' (add '--tenant <tenant-id>' if needed) and re-run this script."
@@ -107,8 +106,8 @@ function Build-Image {
 function Update-App {
     param([string]$AppName, [string]$ImageName)
     if ([string]::IsNullOrEmpty($AppName)) {
-        Write-Host "WARN: Container app name for '$ImageName' not set; skipping image update."
-        return
+        Write-Error "Container app name for '$ImageName' is not set; cannot update its image. Ensure the deployment outputs / azd environment include the container app names so the app is not left on the placeholder image."
+        exit 1
     }
     Write-Host "==> Updating container app '$AppName' -> $RegistryEndpoint/${ImageName}:$ImageTag"
     az containerapp update `

--- a/scripts/deploy_container_images.ps1
+++ b/scripts/deploy_container_images.ps1
@@ -63,6 +63,14 @@ if ($missing.Count -gt 0) {
     exit 1
 }
 
+# Ensure the Azure CLI is installed before any `az` invocation, so a missing
+# CLI produces a clear, actionable error instead of an opaque failure in the
+# azd hook logs.
+if (-not (Get-Command az -ErrorAction SilentlyContinue)) {
+    Write-Error "Azure CLI ('az') is not installed or not on PATH. Install it from https://learn.microsoft.com/cli/azure/install-azure-cli and re-run."
+    exit 1
+}
+
 # Ensure the Azure CLI has a valid, non-expired login. `az acr build` and
 # `az containerapp update` authenticate via the az CLI (separate from azd), so a
 # stale/expired token here would otherwise fail part-way through the build.

--- a/scripts/deploy_container_images.sh
+++ b/scripts/deploy_container_images.sh
@@ -58,6 +58,15 @@ if [[ ${#missing[@]} -gt 0 ]]; then
   exit 1
 fi
 
+# Ensure the Azure CLI is installed before any `az` invocation. Under `set -e`
+# a missing `az` would otherwise fail with an opaque "command not found" that is
+# hard to diagnose in CI/azd hook logs.
+if ! command -v az >/dev/null 2>&1; then
+  echo "ERROR: Azure CLI ('az') is not installed or not on PATH." >&2
+  echo "       Install it from https://learn.microsoft.com/cli/azure/install-azure-cli and re-run." >&2
+  exit 1
+fi
+
 # Ensure the Azure CLI has a valid, non-expired login. `az acr build` and
 # `az containerapp update` authenticate via the az CLI (separate from azd), so a
 # stale/expired token here would otherwise fail part-way through the build.

--- a/scripts/deploy_container_images.sh
+++ b/scripts/deploy_container_images.sh
@@ -70,6 +70,10 @@ fi
 # Ensure the Azure CLI has a valid, non-expired login. `az acr build` and
 # `az containerapp update` authenticate via the az CLI (separate from azd), so a
 # stale/expired token here would otherwise fail part-way through the build.
+if ! command -v az >/dev/null 2>&1; then
+  echo "ERROR: Azure CLI (az) is not installed or not on PATH." >&2
+  exit 1
+fi
 if ! az account show >/dev/null 2>&1; then
   echo "ERROR: Azure CLI is not authenticated or its token has expired." >&2
   echo "       Run 'az login' (add '--tenant <tenant-id>' if needed) and re-run this script." >&2

--- a/scripts/deploy_container_images.sh
+++ b/scripts/deploy_container_images.sh
@@ -28,7 +28,11 @@ BACKEND_APP="${CONTAINER_API_APP_NAME:-}"
 FRONTEND_APP="${CONTAINER_WEB_APP_NAME:-}"
 PROCESSOR_APP="${CONTAINER_PROCESSOR_APP_NAME:-}"
 
-if [[ -z "$ACR_NAME" || -z "$RESOURCE_GROUP" ]]; then
+# Load values from `azd env get-values` when any required value is missing.
+# This covers not just the registry/resource group but also the container app
+# names and registry endpoint, so a partially-populated environment does not
+# silently skip image updates and leave apps on the placeholder image.
+if [[ -z "$ACR_NAME" || -z "$RESOURCE_GROUP" || -z "$REGISTRY_ENDPOINT" || -z "$BACKEND_APP" || -z "$FRONTEND_APP" || -z "$PROCESSOR_APP" ]]; then
   if command -v azd >/dev/null 2>&1; then
     echo "==> Loading missing values from 'azd env get-values'"
     while IFS='=' read -r key value; do
@@ -70,10 +74,6 @@ fi
 # Ensure the Azure CLI has a valid, non-expired login. `az acr build` and
 # `az containerapp update` authenticate via the az CLI (separate from azd), so a
 # stale/expired token here would otherwise fail part-way through the build.
-if ! command -v az >/dev/null 2>&1; then
-  echo "ERROR: Azure CLI (az) is not installed or not on PATH." >&2
-  exit 1
-fi
 if ! az account show >/dev/null 2>&1; then
   echo "ERROR: Azure CLI is not authenticated or its token has expired." >&2
   echo "       Run 'az login' (add '--tenant <tenant-id>' if needed) and re-run this script." >&2
@@ -107,8 +107,9 @@ update_app() {
   local app_name="$1"
   local image_name="$2"
   if [[ -z "$app_name" ]]; then
-    echo "WARN: Container app name for '${image_name}' not set; skipping image update."
-    return
+    echo "ERROR: Container app name for '${image_name}' is not set; cannot update its image." >&2
+    echo "       Ensure the deployment outputs / azd environment include the container app names so the app is not left on the placeholder image." >&2
+    exit 1
   fi
   echo "==> Updating container app '${app_name}' -> ${REGISTRY_ENDPOINT}/${image_name}:${IMAGE_TAG}"
   az containerapp update \

--- a/scripts/deploy_container_images.sh
+++ b/scripts/deploy_container_images.sh
@@ -1,0 +1,118 @@
+#!/usr/bin/env bash
+#
+# deploy_container_images.sh
+#
+# Separate post-deployment script that runs FIRST (before any existing
+# post-deployment scripts). It builds the deployment-specific container images
+# using Azure Container Registry *remote* builds (az acr build - no local Docker
+# required) and pushes them to the dedicated, per-deployment ACR. It then updates
+# the Container Apps to use the freshly pushed images.
+#
+# This intentionally does NOT depend on a shared/public registry or anonymous
+# pull. Image pulls at runtime use identity-based authentication (the app's
+# managed identity has the AcrPull role on the dedicated ACR).
+#
+set -euo pipefail
+
+echo "==> [deploy_container_images] Building and pushing images to the dedicated ACR (remote build)"
+
+# ---------------------------------------------------------------------------
+# Resolve required values. azd exports deployment outputs as environment
+# variables inside hooks; fall back to `azd env get-values` if needed.
+# ---------------------------------------------------------------------------
+ACR_NAME="${AZURE_CONTAINER_REGISTRY_NAME:-}"
+REGISTRY_ENDPOINT="${AZURE_CONTAINER_REGISTRY_ENDPOINT:-}"
+RESOURCE_GROUP="${AZURE_RESOURCE_GROUP:-}"
+IMAGE_TAG="${AZURE_ENV_IMAGE_TAG:-latest_v2}"
+BACKEND_APP="${CONTAINER_API_APP_NAME:-}"
+FRONTEND_APP="${CONTAINER_WEB_APP_NAME:-}"
+PROCESSOR_APP="${CONTAINER_PROCESSOR_APP_NAME:-}"
+
+if [[ -z "$ACR_NAME" || -z "$RESOURCE_GROUP" ]]; then
+  if command -v azd >/dev/null 2>&1; then
+    echo "==> Loading missing values from 'azd env get-values'"
+    while IFS='=' read -r key value; do
+      value="${value%\"}"; value="${value#\"}"
+      case "$key" in
+        AZURE_CONTAINER_REGISTRY_NAME)     ACR_NAME="${ACR_NAME:-$value}" ;;
+        AZURE_CONTAINER_REGISTRY_ENDPOINT) REGISTRY_ENDPOINT="${REGISTRY_ENDPOINT:-$value}" ;;
+        AZURE_RESOURCE_GROUP)              RESOURCE_GROUP="${RESOURCE_GROUP:-$value}" ;;
+        AZURE_ENV_IMAGE_TAG)               IMAGE_TAG="${IMAGE_TAG:-$value}" ;;
+        CONTAINER_API_APP_NAME)            BACKEND_APP="${BACKEND_APP:-$value}" ;;
+        CONTAINER_WEB_APP_NAME)            FRONTEND_APP="${FRONTEND_APP:-$value}" ;;
+        CONTAINER_PROCESSOR_APP_NAME)      PROCESSOR_APP="${PROCESSOR_APP:-$value}" ;;
+      esac
+    done < <(azd env get-values 2>/dev/null || true)
+  fi
+fi
+
+# Derive the login server from the registry name if it was not provided.
+REGISTRY_ENDPOINT="${REGISTRY_ENDPOINT:-${ACR_NAME}.azurecr.io}"
+
+missing=()
+[[ -z "$ACR_NAME" ]]       && missing+=("AZURE_CONTAINER_REGISTRY_NAME")
+[[ -z "$RESOURCE_GROUP" ]] && missing+=("AZURE_RESOURCE_GROUP")
+if [[ ${#missing[@]} -gt 0 ]]; then
+  echo "ERROR: Missing required deployment values: ${missing[*]}" >&2
+  echo "       Ensure infrastructure has been provisioned (azd provision) first." >&2
+  exit 1
+fi
+
+# Ensure the Azure CLI has a valid, non-expired login. `az acr build` and
+# `az containerapp update` authenticate via the az CLI (separate from azd), so a
+# stale/expired token here would otherwise fail part-way through the build.
+if ! az account show >/dev/null 2>&1; then
+  echo "ERROR: Azure CLI is not authenticated or its token has expired." >&2
+  echo "       Run 'az login' (add '--tenant <tenant-id>' if needed) and re-run this script." >&2
+  exit 1
+fi
+
+# Resolve the repository root (this script lives in <root>/scripts).
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ROOT_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+
+echo "    Registry        : $REGISTRY_ENDPOINT ($ACR_NAME)"
+echo "    Resource group  : $RESOURCE_GROUP"
+echo "    Image tag       : $IMAGE_TAG"
+
+# ---------------------------------------------------------------------------
+# Remote build helper - uses ACR Tasks (az acr build) so no local Docker daemon
+# is required on the machine running the deployment.
+# ---------------------------------------------------------------------------
+build_image() {
+  local image_name="$1"
+  local context_dir="$2"
+  echo "==> Remote build (az acr build): ${image_name}:${IMAGE_TAG}"
+  az acr build \
+    --registry "$ACR_NAME" \
+    --image "${image_name}:${IMAGE_TAG}" \
+    --file "${context_dir}/Dockerfile" \
+    "$context_dir"
+}
+
+update_app() {
+  local app_name="$1"
+  local image_name="$2"
+  if [[ -z "$app_name" ]]; then
+    echo "WARN: Container app name for '${image_name}' not set; skipping image update."
+    return
+  fi
+  echo "==> Updating container app '${app_name}' -> ${REGISTRY_ENDPOINT}/${image_name}:${IMAGE_TAG}"
+  az containerapp update \
+    --name "$app_name" \
+    --resource-group "$RESOURCE_GROUP" \
+    --image "${REGISTRY_ENDPOINT}/${image_name}:${IMAGE_TAG}" \
+    --output none
+}
+
+# Build & push all images to the dedicated ACR.
+build_image "backend-api" "${ROOT_DIR}/src/backend-api"
+build_image "processor"   "${ROOT_DIR}/src/processor"
+build_image "frontend"    "${ROOT_DIR}/src/frontend"
+
+# Point the Container Apps at the freshly built images.
+update_app "$BACKEND_APP"   "backend-api"
+update_app "$PROCESSOR_APP" "processor"
+update_app "$FRONTEND_APP"  "frontend"
+
+echo "==> [deploy_container_images] Completed successfully."

--- a/src/backend-api/.dockerignore
+++ b/src/backend-api/.dockerignore
@@ -24,7 +24,8 @@
 **/charts
 **/docker-compose*
 **/compose*
-**/Dockerfile*
+# NOTE: Do not ignore Dockerfile* here - `az acr build` (remote build) uploads
+# this directory as the build context and requires the Dockerfile to be present.
 **/node_modules
 **/npm-debug.log
 **/obj

--- a/src/frontend/.dockerignore
+++ b/src/frontend/.dockerignore
@@ -24,8 +24,8 @@
 **/charts
 **/docker-compose*
 **/compose*
-**/Dockerfile*
-**/*.Dockerfile
+# NOTE: Do not ignore Dockerfile* here - `az acr build` (remote build) uploads
+# this directory as the build context and requires the Dockerfile to be present.
 **/node_modules
 **/npm-debug.log
 **/obj


### PR DESCRIPTION
## Purpose
This pull request introduces a major change to the deployment model: each environment now provisions its own dedicated Azure Container Registry (ACR) for container images, eliminating the reliance on a shared/public registry and anonymous image pulls. All image pulls are now performed using identity-based authentication (AcrPull role via managed identity), and post-deployment scripts have been added to build and push images to the dedicated ACR using remote builds. The infrastructure and documentation have been updated accordingly.

**Azure Container Registry (ACR) Changes**
- Introduced a new `containerRegistry.bicep` module to provision a dedicated ACR per deployment, with identity-based authentication and role assignments for managed identities and the deployer. Admin user and anonymous pull are disabled.
- Updated the main Bicep file (`infra/main.bicep`) to use the new ACR module, output registry details, and assign the AcrPull role to application managed identities.
- Deprecated the old `containerRegistryEndpoint` parameter, now retained only for backward compatibility; deployments no longer depend on a shared/public registry.

**Container App and Image Handling**
- All container apps (`backend-api`, `frontend`, `processor`) are now initially provisioned with a public placeholder image, since the dedicated ACR is empty on first deploy. After images are built and pushed, the apps are updated to use the correct images.  The Bicep modules for container apps are updated to reference the dedicated ACR and configure identity-based registry access. 

**Deployment Scripts**
- Added new post-deployment scripts (`scripts/deploy_container_images.sh` for Bash and `scripts/deploy_container_images.ps1` for PowerShell) that build and push images to the dedicated ACR using `az acr build`, then update the container apps to use the freshly built images. These scripts do not require local Docker and ensure all image pulls are authenticated. 
- Updated deployment hooks in `azure.yaml` to invoke these scripts as the first post-deployment step. 

**Documentation and Miscellaneous**
- Updated the architecture diagram and documentation to reflect the new image pull workflow (identity-based pulls, no anonymous access).
- Updated `.dockerignore` to ensure `Dockerfile` is included in build contexts for remote builds.

These changes significantly improve security and isolation for container image management, streamline the deployment workflow, and remove the dependency on a shared or public registry.

## Does this introduce a breaking change?
<!-- Mark one with an "x". -->

- [ ] Yes
- [X] No


## Golden Path Validation
- [X] I have tested the primary workflows (the "golden path") to ensure they function correctly without errors.

## Deployment Validation
- [X] I have validated the deployment process successfully and all services are running as expected with this change.


## Other Information

This pull request introduces a major change to container image management and deployment. Instead of using a shared or public Azure Container Registry (ACR) with anonymous pull, each deployment now provisions its own dedicated ACR. All image pulls are performed using identity-based authentication (AcrPull role via managed identity), and container images are built and pushed remotely using Azure CLI scripts. This improves security, isolation, and automation for deployments.

The most important changes are:

**Infrastructure and Security Improvements:**
* Provision a dedicated ACR per deployment using the new `infra/modules/containerRegistry.bicep` module, with identity-based AcrPull for app managed identities and registry-scoped AcrPush for the deployer. Admin user and anonymous pull are disabled.
* Container apps (`backend-api`, `frontend`, `processor`) now reference the dedicated ACR for image pulls using managed identity, and initially use a public placeholder image until the deployment-specific images are built and pushed. 
* The `containerRegistryEndpoint` parameter is deprecated and replaced with deployment outputs for the dedicated registry. New outputs are added for registry name, endpoint, and image tag.
**Deployment Automation:**
* New post-deployment scripts (`scripts/deploy_container_images.sh` and `scripts/deploy_container_images.ps1`) build and push images to the dedicated ACR using `az acr build` (no local Docker required), then update the container apps to use the freshly built images. 
* The deployment pipeline (`azure.yaml`) is updated to call these scripts as the first post-provisioning step. 

**Documentation and Miscellaneous:**
* The architecture diagram and documentation are updated to clarify identity-based image pulls and removal of anonymous pull.
* `.dockerignore` is adjusted to ensure `Dockerfile` is included in the build context for remote builds.

These changes significantly improve security, automation, and maintainability of container image management in the deployment process.