### PR TITLE
fix: update container registry module to reference VNet and DNS zone …

### DIFF
--- a/infra/main.bicep
+++ b/infra/main.bicep
@@ -245,10 +245,10 @@ module containerRegistry './modules/containerRegistry.bicep' = {
     networkRuleBypassOptions: 'AzureServices'
     // WAF: host the registry private endpoint in the backend subnet and link it
     // to the privatelink.azurecr.io DNS zone so image pulls resolve privately.
-    // Use deterministic resource IDs here so non-private deployments do not
-    // pick up unconditional dependencies on the conditional network modules.
-    privateEndpointSubnetResourceId: enablePrivateNetworking ? resourceId(resourceGroup().name, 'Microsoft.Network/virtualNetworks/subnets', 'vnet-${solutionSuffix}', 'backend') : ''
-    privateDnsZoneResourceId: enablePrivateNetworking ? resourceId(resourceGroup().name, 'Microsoft.Network/privateDnsZones', 'privatelink.azurecr.io') : ''
+    // Reference the VNet and DNS zone outputs directly to avoid case-sensitivity
+    // issues with manually constructed resource IDs.
+    privateEndpointSubnetResourceId: enablePrivateNetworking ? virtualNetwork!.outputs.backendSubnetResourceId : ''
+    privateDnsZoneResourceId: enablePrivateNetworking ? avmPrivateDnsZones[dnsZoneIndex.containerRegistry]!.outputs.resourceId : ''
     // Application managed identity gets AcrPull for identity-based image pulls.
     acrPullPrincipalIds: [
       appIdentity.outputs.principalId


### PR DESCRIPTION
…outputs directly

## Purpose
This pull request updates how the container registry module references resource IDs for private networking in `infra/main.bicep`. Instead of manually constructing resource IDs, it now directly uses output values from the relevant modules, which helps avoid issues related to case sensitivity and ensures more reliable deployments.

**Networking resource ID references:**

* Changed `privateEndpointSubnetResourceId` to use the output from the `virtualNetwork` module instead of constructing the resource ID manually, preventing case-sensitivity issues and accidental dependencies.
* Changed `privateDnsZoneResourceId` to use the output from the `avmPrivateDnsZones` module, ensuring accurate and consistent resource ID references.

## Does this introduce a breaking change?
<!-- Mark one with an "x". -->

- [ ] Yes
- [X] No


## Golden Path Validation
- [X] I have tested the primary workflows (the "golden path") to ensure they function correctly without errors.

## Deployment Validation
- [X] I have validated the deployment process successfully and all services are running as expected with this change.


## Other Information

This pull request updates how resource IDs are referenced for the container registry's private networking configuration in `main.bicep`. Instead of manually constructing resource IDs, the code now references the output values from the relevant modules directly. This change helps prevent case-sensitivity issues and ensures more robust and maintainable infrastructure code.

**Improvements to resource ID handling:**

* Updated `privateEndpointSubnetResourceId` to use `virtualNetwork.outputs.backendSubnetResourceId` instead of constructing the resource ID manually.
* Updated `privateDnsZoneResourceId` to use `avmPrivateDnsZones[dnsZoneIndex.containerRegistry].outputs.resourceId` instead of constructing the resource ID manually.